### PR TITLE
Adding c# examples for call, dequeue, and redirect

### DIFF
--- a/rest/taskrouter/reservations/call/example-1.cs
+++ b/rest/taskrouter/reservations/call/example-1.cs
@@ -1,0 +1,29 @@
+// Download the twilio-csharp library from twilio.com/docs/csharp/install
+using System;
+using Twilio.TaskRouter;
+
+class Example
+{
+  static void Main(string[] args)
+  {
+    // Find your Account Sid and Auth Token at twilio.com/user/account
+    string AccountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string AuthToken = "your_auth_token";
+    string WorkspaceSid = "WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string TaskSid = "WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string ReservationSid = "WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    var client = new TaskRouterClient(AccountSid, AuthToken);
+
+    // Update a Reservation with a Call instruction
+    Reservation reservation = client.GetReservation(WorkspaceSid, TaskSid, ReservationSid);
+    Console.WriteLine(reservation.ReservationStatus);
+    Console.WriteLine(reservation.WorkerName);
+
+    client.UpdateReservation(WorkspaceSid, "Tasks", TaskSid, ReservationSid,
+        instruction: "call",
+        callFrom: "+19876543210",
+        callUrl: "http://example.com/agent_answer",
+        callStatusCallbackUrl: "http://example.com/agent_answer_status_callback",
+        callAccept: "true");
+  }
+}

--- a/rest/taskrouter/reservations/dequeue/example-1.cs
+++ b/rest/taskrouter/reservations/dequeue/example-1.cs
@@ -1,0 +1,26 @@
+// Download the twilio-csharp library from twilio.com/docs/csharp/install
+using System;
+using Twilio.TaskRouter;
+
+class Example
+{
+  static void Main(string[] args)
+  {
+    // Find your Account Sid and Auth Token at twilio.com/user/account
+    string AccountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string AuthToken = "your_auth_token";
+    string WorkspaceSid = "WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string TaskSid = "WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string ReservationSid = "WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    var client = new TaskRouterClient(AccountSid, AuthToken);
+
+    // Update a Reservation with a Dequeue instruction
+    Reservation reservation = client.GetReservation(WorkspaceSid, TaskSid, ReservationSid);
+    Console.WriteLine(reservation.ReservationStatus);
+    Console.WriteLine(reservation.WorkerName);
+
+    client.UpdateReservation(WorkspaceSid, "Tasks", TaskSid, ReservationSid,
+        instruction: "dequeue",
+        dequeueFrom: "+18001231234");
+  }
+}

--- a/rest/taskrouter/reservations/redirect/example-1.cs
+++ b/rest/taskrouter/reservations/redirect/example-1.cs
@@ -1,0 +1,27 @@
+// Download the twilio-csharp library from twilio.com/docs/csharp/install
+using System;
+using Twilio.TaskRouter;
+
+class Example
+{
+  static void Main(string[] args)
+  {
+    // Find your Account Sid and Auth Token at twilio.com/user/account
+    string AccountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string AuthToken = "your_auth_token";
+    string WorkspaceSid = "WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string TaskSid = "WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    string ReservationSid = "WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    var client = new TaskRouterClient(AccountSid, AuthToken);
+
+    // Update a Reservation with a Redirect instruction
+    Reservation reservation = client.GetReservation(WorkspaceSid, TaskSid, ReservationSid);
+    Console.WriteLine(reservation.ReservationStatus);
+    Console.WriteLine(reservation.WorkerName);
+
+    client.UpdateReservation(WorkspaceSid, "Tasks", TaskSid, ReservationSid,
+        instruction: "Redirect",
+        redirectCallSid: "CA123456789",
+        redirectUrl: "http://example.com/assignment_redirect");
+  }
+}


### PR DESCRIPTION
C# code snippets are currently missing on TaskRouter Update a Reservation REST docs for Call, Dequeue, Redirect instructions. 

