### PR TITLE
Adjusts to handle default data message

### DIFF
--- a/notifications/register/receive-notification-android/receive-notification-android.java
+++ b/notifications/register/receive-notification-android/receive-notification-android.java
@@ -1,12 +1,8 @@
 private static final String TAG = "MyGcmListenerService";
   @Override
   public void onMessageReceived(String from, Bundle data) {
-    Bundle notification = data.getBundle("notification");
-    String body = "";
-    if (notification != null) {
-      body = notification.getString("body");
-    }
-    Log.d(TAG, "From: " + from);
-    Log.d(TAG, "Body: " + body);
+     String body = data.getString("twi_body");
+     Log.d(TAG, "From: " + from);
+     Log.d(TAG, "Body: " + body);
   }
 }


### PR DESCRIPTION
From Oct 3 2016, GCM notifications are by default data messages with the Body parameter translated to twi_body in the data bundle. This change adjusts the code sample to reflect that.