### PR TITLE
Update local-get-basic-example-5.7.x.java

### DIFF
--- a/rest/available-phone-numbers/local-basic-example-5/local-get-basic-example-5.7.x.java
+++ b/rest/available-phone-numbers/local-basic-example-5/local-get-basic-example-5.7.x.java
@@ -14,7 +14,7 @@ public class Example {
   public static void main(String[] args) {
     Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
 
-    ResourceSet<Local> numbers = Local.reader("GB").setContains("4420").read();
+    ResourceSet<Local> numbers = Local.reader("GB").setContains("+4420").read();
 
     // Purchase the first number on the list.
     PhoneNumber availableNumber = numbers.iterator().next().getPhoneNumber();


### PR DESCRIPTION
If '+' is not present the API returns numbers that contain "4420" in the middle of the phone number and not at the beginning.