### PR TITLE
Updated PHP get call list examples

### DIFF
--- a/rest/call/list-get-example-3/list-get-example-3.5.x.php
+++ b/rest/call/list-get-example-3/list-get-example-3.5.x.php
@@ -9,7 +9,7 @@ $token = "your_auth_token";
 $client = new Client($sid, $token);
 
 $calls = $client->calls->read(
-    array("status" => "completed", "starttimeAfter" => "2009-07-06")
+    array("status" => "completed", "startTimeAfter" => "2009-07-06")
 );
 // Loop over the list of calls and echo a property for each one
 foreach ($calls as $call) {

--- a/rest/call/list-get-example-4/list-get-example-4.5.x.php
+++ b/rest/call/list-get-example-4/list-get-example-4.5.x.php
@@ -11,8 +11,8 @@ $client = new Client($sid, $token);
 $calls = $client->calls->read(
     array(
         "status" => "in-progress",
-        "starttimeAfter" => "2009-07-04",
-        "starttimeBefore" => "2009-07-06"
+        "startTimeAfter" => "2009-07-04",
+        "startTimeBefore" => "2009-07-06"
     )
 );
 // Loop over the list of calls and echo a property for each one


### PR DESCRIPTION
Updated startTimeAfter and startTimeBefore to reflect the correct syntax as defined in the PHP Helper library.