### PR TITLE
Switching to TaskRouterWorkspaceCapability()

### DIFF
--- a/rest/taskrouter/jwts/workspace/example-1/example-1.2.x.js
+++ b/rest/taskrouter/jwts/workspace/example-1/example-1.2.x.js
@@ -7,7 +7,7 @@ var authToken = "your_auth_token";
 var workspaceSid = "WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 var workerSid = "WKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
-var capability = new twilio.TaskRouterTaskQueueCapability(accountSid, authToken, workspaceSid, workerSid);
+var capability = new twilio.TaskRouterWorkspaceCapability(accountSid, authToken, workspaceSid, workerSid);
 capability.allowFetchSubresources();
 capability.allowUpdatesSubresources();
 capability.allowDeleteSubresources();

--- a/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
+++ b/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
@@ -7,7 +7,7 @@ const authToken = 'your_auth_token';
 const workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const workerSid = 'WKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 
-const capability = new twilio.jwt.TaskRouterTaskQueueCapability(accountSid,
+const capability = new twilio.jwt.TaskRouterWorkspaceCapability(accountSid,
   authToken,
   workspaceSid,
   workerSid);


### PR DESCRIPTION
Node examples for TaskRouter.js Workspace incorrectly uses TaskRouterTaskQueueCapability(). Changing to TaskRouterWorkspaceCapability().