### PR TITLE
iOS TwilioVideo 1.0.0-beta9 changes

### DIFF
--- a/video/getting-started/connect-to-room/connect-to-room.m
+++ b/video/getting-started/connect-to-room/connect-to-room.m
@@ -1,9 +1,10 @@
-TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithBlock:^(TVIConnectOptionsBuilder * _Nonnull builder) {
+TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:self.accessToken
+                                                                  block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     builder.name = @"my-room";
     builder.localMedia = self.localMedia;
 }];
 
-TVIRoom *room = [videoClient connectWithOptions:connectOptions delegate:self];
+TVIRoom *room = [TVIVideoClient connectWithOptions:connectOptions delegate:self];
 
 #pragma mark - TVIRoomDelegate
 

--- a/video/getting-started/connect-to-room/connect-to-room.swift
+++ b/video/getting-started/connect-to-room/connect-to-room.swift
@@ -1,8 +1,8 @@
-let connectOptions = TVIConnectOptions { (builder) in
+let connectOptions = TVIConnectOptions.init(token: accessToken) { (builder) in
     builder.name = "my-room"
     builder.localMedia = self.localMedia
 }
-room = videoClient.connect(with: connectOptions, delegate: self)
+room = TVIVideoClient.connect(with: connectOptions, delegate: self)
 
 // MARK: TVIRoomDelegate
 

--- a/video/getting-started/create-video-client/create-video-client.m
+++ b/video/getting-started/create-video-client/create-video-client.m
@@ -1,1 +1,1 @@
-Starting TwilioVideo version 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 
+As of 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 

--- a/video/getting-started/create-video-client/create-video-client.m
+++ b/video/getting-started/create-video-client/create-video-client.m
@@ -1,1 +1,1 @@
-TVIVideoClient *videoClient = [TVIVideoClient clientWithToken:accessToken];
+Starting TwilioVideo version 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 

--- a/video/getting-started/create-video-client/create-video-client.swift
+++ b/video/getting-started/create-video-client/create-video-client.swift
@@ -1,1 +1,1 @@
-Starting TwilioVideo version 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 
+As of 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 

--- a/video/getting-started/create-video-client/create-video-client.swift
+++ b/video/getting-started/create-video-client/create-video-client.swift
@@ -1,1 +1,1 @@
-var videoClient = TVIVideoClient(token: accessToken)
+Starting TwilioVideo version 1.0.0-beta9, you are no longer required to create a TVIVideoClient object. Instead you can connect to a Room using TVIVideoClient's class method. 

--- a/video/getting-started/handle-participants/handle-participants.m
+++ b/video/getting-started/handle-participants/handle-participants.m
@@ -1,8 +1,9 @@
-TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithBlock:^(TVIConnectOptionsBuilder * _Nonnull builder) {
+TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:self.accessToken
+                                                                  block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     builder.name = @"my-room";
     builder.localMedia = self.localMedia;
 }];
-TVIRoom *room = [videoClient connectWithOptions:connectOptions delegate:self];
+TVIRoom *room = [TVIVideoClient connectWithOptions:connectOptions delegate:self];
 
 #pragma mark - TVIRoomDelegate
 

--- a/video/getting-started/handle-participants/handle-participants.swift
+++ b/video/getting-started/handle-participants/handle-participants.swift
@@ -1,8 +1,8 @@
-let connectOptions = TVIConnectOptions { (builder) in
+let connectOptions = TVIConnectOptions.init(token: accessToken) { (builder) in
     builder.name = "my-room"
     builder.localMedia = self.localMedia
 }
-room = videoClient.connect(with: connectOptions, delegate: self)
+room = TVIVideoClient.connect(with: connectOptions, delegate: self)
 
 // MARK: TVIRoomDelegate
 

--- a/video/rooms/create-room/create-room.m
+++ b/video/rooms/create-room/create-room.m
@@ -1,12 +1,13 @@
 -(void)createARoom {
-	// Create a room 
-	TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithBlock:^(TVIConnectOptionsBuilder * _Nonnull builder) {
-		builder.name = @"my-new-room";
-	}];
-	TVIRoom *room = [videoClient connectWithOptions:connectOptions delegate:self];
+    // Create a room 
+    TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:self.accessToken
+                                                                      block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
+        builder.name = @"my-new-room";
+    }];
+    TVIRoom *room = [TVIVideoClient connectWithOptions:connectOptions delegate:self];
 }
 
 #pragma mark - TVIRoomDelegate
-- (void)room:(TVIRoom *)room participantDidConnect:(TVIParticipant *)participant {
-	NSLog(@"Participant did connect:%@", participant.identity);
+func didConnect(to room: TVIRoom) {
+    NSLog(@"Did connect to Room");
 }

--- a/video/rooms/create-room/create-room.m
+++ b/video/rooms/create-room/create-room.m
@@ -8,6 +8,7 @@
 }
 
 #pragma mark - TVIRoomDelegate
-func didConnect(to room: TVIRoom) {
+
+- (void)didConnectedToRoom:(nonnull TVIRoom *)room {
     NSLog(@"Did connect to Room");
 }

--- a/video/rooms/create-room/create-room.swift
+++ b/video/rooms/create-room/create-room.swift
@@ -1,11 +1,11 @@
 @IBAction func createARoom(sender: AnyObject) {
-    let connectOptions = TVIConnectOptions.init(block: { (builder) in
+    let connectOptions = TVIConnectOptions.init(token: accessToken) { (builder) in
         builder.name = "my-room"
-    })
-    room = videoClient.connectWithOptions(connectOptions, delegate: self)
+    }
+    room = TVIVideoClient.connect(with: connectOptions, delegate: self)
 }
 
 // MARK: TVIRoomDelegate
 func didConnectToRoom(room: TVIRoom) {
-    print("Did connect to room")
+    print("Did connect to Room")
 }

--- a/video/rooms/create-room/create-room.swift
+++ b/video/rooms/create-room/create-room.swift
@@ -6,6 +6,7 @@
 }
 
 // MARK: TVIRoomDelegate
+
 func didConnectToRoom(room: TVIRoom) {
     print("Did connect to Room")
 }

--- a/video/rooms/disconnect-from-room/disconnect-from-room.m
+++ b/video/rooms/disconnect-from-room/disconnect-from-room.m
@@ -2,7 +2,9 @@
 [self.room disconnect];
 
 // This results in a callback to TVIRoomDelegate#room:didDisconnectWithError
-#pragma mark - TVIRoomDelegate methods
+
+#pragma mark - TVIRoomDelegate
+
 - (void)room:(TVIRoom *)room didDisconnectWithError:(NSError *)error {
     NSLog(@"Did disconnect from room");
 }

--- a/video/rooms/disconnect-from-room/disconnect-from-room.swift
+++ b/video/rooms/disconnect-from-room/disconnect-from-room.swift
@@ -2,7 +2,9 @@
 room.disconnect()
 
 // This results in a callback to TVIRoomDelegate#room:didDisconnectWithError
+
 // MARK: TVIRoomDelegate
+
 func room(_ room: TVIRoom, didDisconnectWithError error: Error?) {
     print("Disconnected from room \(room.name)")
 }

--- a/video/rooms/display-participants-video/display-participants-video.m
+++ b/video/rooms/display-participants-video/display-participants-video.m
@@ -1,4 +1,4 @@
-#pragma mark - TVIRoomDelegate methods
+#pragma mark - TVIRoomDelegate
 
 // First, we set a Participant Delegate when a Participant first connects: 
 - (void)room:(TVIRoom *)room participantDidConnect:(TVIParticipant *)participant {
@@ -9,7 +9,8 @@
 /* In the Participant Delegate, we can respond when the Participant adds a Video
 Track by rendering it on screen:*/
 
-#pragma mark - TVIParticipantDelegate methods
+#pragma mark - TVIParticipantDelegate
+
 - (void)participant:(TVIParticipant *)participant addedVideoTrack:(TVIVideoTrack *)videoTrack {
     NSLog(@"Participant %@ added a video track",participant.identity);
     videoTrack.delegate = self;
@@ -17,7 +18,9 @@ Track by rendering it on screen:*/
 }
 
 // Lastly, we can subscribe to important events on the Video Track
-#pragma mark - TVIVideoTrackDelegate methods
+
+#pragma mark - TVIVideoTrackDelegate 
+
 - (void)videoTrack:(TVIVideoTrack *)track dimensionsDidChange:(CMVideoDimensions)dimensions {
     NSLog(@"Dimensions changed to: %d x %d", dimensions.width, dimensions.height);
     [self.view setNeedsUpdateConstraints];

--- a/video/rooms/display-participants-video/display-participants-video.swift
+++ b/video/rooms/display-participants-video/display-participants-video.swift
@@ -1,6 +1,7 @@
 // First, we set a Participant Delegate when a Participant first connects: 
 
 // MARK: TVIRoomDelegate
+
 func room(_ room: TVIRoom, participantDidConnect participant: TVIParticipant) {
 	print("Participant connected: \(participant.identity!)")
 	participant.delegate = self
@@ -10,6 +11,7 @@ func room(_ room: TVIRoom, participantDidConnect participant: TVIParticipant) {
 Track by rendering it on screen: */
 
 // MARK: TVIParticipantDelegate
+
 func participant(_ participant: TVIParticipant, addedVideoTrack videoTrack: TVIVideoTrack) {
 	print("Participant \(participant.identity) added video track")
 	videoTrack.attach(self.remoteMediaView)
@@ -20,6 +22,7 @@ func participant(_ participant: TVIParticipant, addedVideoTrack videoTrack: TVIV
 // Lastly, we can subscribe to important events on the Video Track
 
 // MARK: TVIVideoTrackDelegate
+
 func videoTrack(_ track: TVIVideoTrack, dimensionsDidChange dimensions: CMVideoDimensions) {
 	print("The dimensions of the video track changed to: \(dimensions.width)x\(dimensions.height)")
 }

--- a/video/rooms/handle-participant-events/handle-participant-events.m
+++ b/video/rooms/handle-participant-events/handle-participant-events.m
@@ -1,4 +1,5 @@
-#pragma mark - TVIParticipantDelegate methods
+#pragma mark - TVIParticipantDelegate
+
 - (void)participant:(TVIParticipant *)participant addedVideoTrack:(TVIVideoTrack *)videoTrack {
     NSLog(@"Participant %@ added a video track",participant.identity);
 }

--- a/video/rooms/handle-participant-events/handle-participant-events.swift
+++ b/video/rooms/handle-participant-events/handle-participant-events.swift
@@ -1,4 +1,5 @@
 // MARK: TVIParticipantDelegate
+
 func participant(_ participant: TVIParticipant, addedVideoTrack videoTrack: TVIVideoTrack) {
     NSLog("Participant \(participant.identity) added video track")
 }

--- a/video/rooms/join-room/join-room.m
+++ b/video/rooms/join-room/join-room.m
@@ -7,6 +7,7 @@
 }
 
 #pragma mark - TVIRoomDelegate
+
 - (void)room:(TVIRoom *)room participantDidConnect:(TVIParticipant *)participant {
 	NSLog(@"Participant did connect:%@", participant.identity);
 }

--- a/video/rooms/join-room/join-room.swift
+++ b/video/rooms/join-room/join-room.swift
@@ -6,6 +6,7 @@
 }
 
 // MARK: TVIRoomDelegate
+
 func didConnectToRoom(room: TVIRoom) {
     print("Did connect to room")
 }


### PR DESCRIPTION
**iOS TwilioVideo 1.0.0-beta9 changes:** 
It is no longer necessary to create a TVIVideoClient. Instead there is a class method which connects to a Room.