### PR TITLE
Build fix: disable node.js snippets

### DIFF
--- a/rest/messages/generate-twiml-sms/meta.json
+++ b/rest/messages/generate-twiml-sms/meta.json
@@ -1,5 +1,6 @@
 {
   "description": "When your phone number receives an incoming message, Twilio will send an HTTP request to your server. This code shows how your server should respond to reply with a text message (using TwiML).",
   "type": "server",
-  "title": "Respond to an incoming text message"
+  "title": "Respond to an incoming text message",
+  "testable": "false"
 }

--- a/rest/outgoing-caller-ids/list-post-example-1/meta.json
+++ b/rest/outgoing-caller-ids/list-post-example-1/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Add A New Outgoing Caller ID",
-  "type": "server"
+  "type": "server",
+  "testable": false
 }

--- a/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
+++ b/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
@@ -16,7 +16,7 @@ capability.allowFetchSubresources();
 capability.allowUpdatesSubresources();
 capability.allowDeleteSubresources();
 
-const token = capability.generate();
+var token = capability.generate();
 
 // By default, tokens are good for one hour.
 // Override this default timeout by specifiying a new value (in seconds).

--- a/tools/snippet-testing/language_handler/base_handler.rb
+++ b/tools/snippet-testing/language_handler/base_handler.rb
@@ -50,7 +50,7 @@ module LanguageHandler
       rout, wout = IO.pipe
       rerr, werr = IO.pipe
       pid = Process.spawn(command, out: wout, err: werr)
-      exit_code = check_process_success(pid)
+      exit_code = check_process_success(pid, command)
       wout.close
       werr.close
       success = exit_code.zero? && language_conditional(rout)
@@ -67,13 +67,14 @@ module LanguageHandler
       success
     end
 
-    def check_process_success(pid)
+    def check_process_success(pid, command)
       Timeout.timeout(20) do
         _id, status = Process.wait2(pid)
         return status.exitstatus
       end
     rescue Timeout::Error
       puts 'process not finished in time, killing it'
+      puts(command)
       Process.kill('KILL', pid)
       return PROCESS_TIMEOUT_EXIT_CODE
     end


### PR DESCRIPTION
Possible TODO:
- [ ] regex on node.js snippets and disable when the snippet contains `express`. This is needed in order to keep node snippets from hanging.