### PR TITLE
Change old 'notifications' property to 'notify'

### DIFF
--- a/notifications/register/create-binding-server-apns/create-binding.js
+++ b/notifications/register/create-binding-server-apns/create-binding.js
@@ -5,7 +5,7 @@ app.post('/register', function(request, response) {
   var client = new twilio(env.TWILIO_ACCOUNT_SID,  env.TWILIO_AUTH_TOKEN);
 
   // Get a reference to the user notification service instance
-  var service = client.notifications.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
+  var service = client.notify.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
 
   return service.bindings.create({
     "endpoint": request.body.endpoint,

--- a/notifications/register/create-binding-server/create-binding.js
+++ b/notifications/register/create-binding-server/create-binding.js
@@ -5,7 +5,7 @@ app.post('/register', function(request, response) {
   var client = new twilio(env.TWILIO_ACCOUNT_SID,  env.TWILIO_AUTH_TOKEN);
 
   // Get a reference to the user notification service instance
-  var service = client.notifications.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
+  var service = client.notify.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
 
   return service.bindings.create({
     "endpoint": request.body.endpoint,

--- a/notifications/register/send-notification-1/send-notification-1.js
+++ b/notifications/register/send-notification-1/send-notification-1.js
@@ -8,7 +8,7 @@ var twilio = require('twilio');
 var client = new twilio(env.TWILIO_ACCOUNT_SID,  env.TWILIO_AUTH_TOKEN);
 
 // Create a reference to the user notification service
-var service = client.notifications.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
+var service = client.notify.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
 
 // Send a notification
 service.notifications.create({

--- a/notifications/register/send-notification-2/send-notification-2.js
+++ b/notifications/register/send-notification-2/send-notification-2.js
@@ -8,7 +8,7 @@ var twilio = require('twilio');
 var client = new twilio(env.TWILIO_ACCOUNT_SID,  env.TWILIO_AUTH_TOKEN);
 
 // Create a reference to the user notification service
-var service = client.notifications.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
+var service = client.notify.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
 
 // Send a notification
 service.notifications.create({

--- a/notifications/register/send-notification/send-notification.js
+++ b/notifications/register/send-notification/send-notification.js
@@ -8,7 +8,7 @@ var twilio = require('twilio');
 var client = new twilio(env.TWILIO_ACCOUNT_SID,  env.TWILIO_AUTH_TOKEN);
 
 // Create a reference to the user notification service
-var service = client.notifications.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
+var service = client.notify.services(env.TWILIO_NOTIFICATION_SERVICE_SID);
 
 // Send a notification
 service.notifications

--- a/notifications/sms-quickstart/create-binding/example.js
+++ b/notifications/sms-quickstart/create-binding/example.js
@@ -6,7 +6,7 @@ var authToken = 'your_auth_token';
 var Twilio = require('twilio');
 
 var client = new Twilio(accountSid, authToken);
-var service = client.notifications.services('ISxxx');
+var service = client.notify.services('ISxxx');
 
 // Create a binding for a user that will be updated when details for Rogue
 // One or the Han Solo spinoff are revealed

--- a/notifications/sms-quickstart/send-notification/example.js
+++ b/notifications/sms-quickstart/send-notification/example.js
@@ -6,7 +6,7 @@ var authToken = 'your_auth_token';
 var Twilio = require('twilio');
 
 var client = new Twilio(accountSid, authToken);
-var service = client.notifications.services('ISxxx');
+var service = client.notify.services('ISxxx');
 
 // Send a notification to all users who have subscribed for Rogue One updates
 service.notifications.create({


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/DEVED-2191

When setting the Notify client, refer to 'notify' instead of 'notifications':
Old: var service = client.notifications.v1.services('ISxxx')
New: var service = client.notify.v1.services('ISxxx')

I did double-check that we're using the appropriate client.notify syntax in all other languages for these code samples.