### PR TITLE
Fixed 'Setup Local Media' (ObjC)

### DIFF
--- a/video/getting-started/setup-local-media/setup-local-media.m
+++ b/video/getting-started/setup-local-media/setup-local-media.m
@@ -11,9 +11,6 @@ TVICameraCapturer *camera = = [[TVICameraCapturer alloc] init];
 // Add a video track
 TVILocalVideoTrack *localVideoTrack = [localMedia addVideoTrack:enable capturer:camera];
 
-// Connect and share your local media
-TVIRoom *room = [videoClient connectWithOptions:connectOptions delegate:self];
-
 // Remove audio track
 [localMedia removeAudioTrack:localAudioTrack];
 


### PR DESCRIPTION
Hi, I found this piece of code confusing on [your guide](https://www.twilio.com/docs/api/video/getting-started) so I think that the best is to remove it:

```
// Connect and share your local media
TVIRoom *room = [videoClient connectWithOptions:connectOptions delegate:self];
```

- videoClient is not declared above so it's misleading and doesn't compile.
- there's no interaction between `videoClient` and `localMedia` so I don't see the point of declaring that piece of code in that snippet.