### PR TITLE
Change binding type to apn in C# and Java snippets(notify)

### DIFF
--- a/notifications/rest/bindings/create-binding/create-binding.5.x.cs
+++ b/notifications/rest/bindings/create-binding/create-binding.5.x.cs
@@ -19,7 +19,7 @@ public class Example
             serviceSid,
             "endpoint",
             "00000001",
-            BindingResource.BindingTypeEnum.Gcm,
+            BindingResource.BindingTypeEnum.Apn,
             "device_token",
             new List<string> { "preferred device", "new user" });
 

--- a/notifications/rest/bindings/create-binding/create-binding.7.x.java
+++ b/notifications/rest/bindings/create-binding/create-binding.7.x.java
@@ -25,7 +25,7 @@ public class Example {
       SERVICE_SID,
       "endpoint_id",
       "00000001",
-      Binding.BindingType.GCM,
+      Binding.BindingType.APN,
       "device_token"
     )
     .setTag(tags)


### PR DESCRIPTION
The binding type for these snippets should be apn, not gcm. 