### PR TITLE
Review and cleanup of new permission snippets

### DIFF
--- a/sync/rest/document-permissions/delete-permission/delete-permission.5.x.cs
+++ b/sync/rest/document-permissions/delete-permission/delete-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.Document;
+using Twilio.Rest.Sync.V1.Service.Document;
 
 public class Example
 {

--- a/sync/rest/document-permissions/delete-permission/delete-permission.5.x.php
+++ b/sync/rest/document-permissions/delete-permission/delete-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->documents('MyFirstDocument')
                  ->documentPermissions('bob')

--- a/sync/rest/document-permissions/delete-permission/delete-permission.5.x.rb
+++ b/sync/rest/document-permissions/delete-permission/delete-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.documents('MyFirstDocument')

--- a/sync/rest/document-permissions/delete-permission/delete-permission.6.x.py
+++ b/sync/rest/document-permissions/delete-permission/delete-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-did_delete = client.preview \
-                   .sync \
+did_delete = client.sync \
                    .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                    .documents("MyFirstDocument") \
                    .document_permissions("bob") \

--- a/sync/rest/document-permissions/delete-permission/delete-permission.7.x.java
+++ b/sync/rest/document-permissions/delete-permission/delete-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.document.DocumentPermission;
+import com.twilio.rest.sync.v1.service.document.DocumentPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/document-permissions/list-permissions/list-permissions.5.x.cs
+++ b/sync/rest/document-permissions/list-permissions/list-permissions.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.Document;
+using Twilio.Rest.Sync.V1.Service.Document;
 
 public class Example
 {

--- a/sync/rest/document-permissions/list-permissions/list-permissions.5.x.php
+++ b/sync/rest/document-permissions/list-permissions/list-permissions.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$documents = $client->preview->sync
+$documents = $client->sync
                     ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                     ->documents('MyFirstDocument')
                     ->documentPermissions

--- a/sync/rest/document-permissions/list-permissions/list-permissions.5.x.rb
+++ b/sync/rest/document-permissions/list-permissions/list-permissions.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.documents('MyFirstDocument')

--- a/sync/rest/document-permissions/list-permissions/list-permissions.6.x.py
+++ b/sync/rest/document-permissions/list-permissions/list-permissions.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-document_permissions = client.preview \
-                             .sync \
+document_permissions = client.sync \
                              .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                              .documents("MyFirstDocument") \
                              .document_permissions \

--- a/sync/rest/document-permissions/list-permissions/list-permissions.7.x.java
+++ b/sync/rest/document-permissions/list-permissions/list-permissions.7.x.java
@@ -2,7 +2,7 @@
 
 import com.twilio.Twilio;
 import com.twilio.base.ResourceSet;
-import com.twilio.rest.preview.sync.service.document.DocumentPermission;
+import com.twilio.rest.sync.v1.service.document.DocumentPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/document-permissions/list-permissions/output/list-permissions.json
+++ b/sync/rest/document-permissions/list-permissions/output/list-permissions.json
@@ -3,20 +3,20 @@
     {
       "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "document_sid": "MyFirstDocument",
+      "document_sid": "ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "identity": "bob",
       "read": true,
       "write": true,
       "manage": false,
-      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/MyFirstDocument/Permissions/bob"
+      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
     }
   ],
   "meta": {
     "page": 0,
     "page_size": 50,
-    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/MyFirstDocument/Permissions?PageSize=50&Page=0",
+    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "previous_page_url": null,
-    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/MyFirstDocument/Permissions?PageSize=50&Page=0",
+    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "next_page_url": null,
     "key": "permissions"
   }

--- a/sync/rest/document-permissions/retrieve-permission/output/retrieve-permission.json
+++ b/sync/rest/document-permissions/retrieve-permission/output/retrieve-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "document_sid": "MyFirstDocument",
+  "document_sid": "ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/MyFirstDocument/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.cs
+++ b/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.Document;
+using Twilio.Rest.Sync.V1.Service.Document;
 
 public class Example
 {

--- a/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.php
+++ b/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$document = $client->preview->sync
+$document = $client->sync
                    ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                    ->documents('MyFirstDocument')
                    ->documentPermissions('bob')

--- a/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.rb
+++ b/sync/rest/document-permissions/retrieve-permission/retrieve-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.documents('MyFirstDocument')

--- a/sync/rest/document-permissions/retrieve-permission/retrieve-permission.6.x.py
+++ b/sync/rest/document-permissions/retrieve-permission/retrieve-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-document_permission = client.preview \
-                            .sync \
+document_permission = client.sync \
                             .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                             .documents("MyFirstDocument") \
                             .document_permissions("bob") \

--- a/sync/rest/document-permissions/retrieve-permission/retrieve-permission.7.x.java
+++ b/sync/rest/document-permissions/retrieve-permission/retrieve-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.document.DocumentPermission;
+import com.twilio.rest.sync.v1.service.document.DocumentPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/document-permissions/update-permission/output/update-permission.json
+++ b/sync/rest/document-permissions/update-permission/output/update-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "document_sid": "MyFirstDocument",
+  "document_sid": "ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/MyFirstDocument/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Documents/ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/document-permissions/update-permission/update-permission.5.x.cs
+++ b/sync/rest/document-permissions/update-permission/update-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.Document;
+using Twilio.Rest.Sync.V1.Service.Document;
 
 public class Example
 {

--- a/sync/rest/document-permissions/update-permission/update-permission.5.x.php
+++ b/sync/rest/document-permissions/update-permission/update-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->documents('MyFirstDocument')
                  ->documentPermissions('bob')

--- a/sync/rest/document-permissions/update-permission/update-permission.5.x.rb
+++ b/sync/rest/document-permissions/update-permission/update-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.documents('MyFirstDocument')

--- a/sync/rest/document-permissions/update-permission/update-permission.6.x.py
+++ b/sync/rest/document-permissions/update-permission/update-permission.6.x.py
@@ -8,8 +8,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-document_permission = client.preview \
-                            .sync \
+document_permission = client.sync \
                             .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                             .documents("MyFirstDocument") \
                             .document_permissions("bob") \

--- a/sync/rest/document-permissions/update-permission/update-permission.7.x.java
+++ b/sync/rest/document-permissions/update-permission/update-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.document.DocumentPermission;
+import com.twilio.rest.sync.v1.service.document.DocumentPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/list-permissions/delete-permission/delete-permission.5.x.cs
+++ b/sync/rest/list-permissions/delete-permission/delete-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncList;
+using Twilio.Rest.Sync.V1.Service.SyncList;
 
 public class Example
 {

--- a/sync/rest/list-permissions/delete-permission/delete-permission.5.x.php
+++ b/sync/rest/list-permissions/delete-permission/delete-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->syncLists('MyFirstList')
                  ->syncListPermissions('bob')

--- a/sync/rest/list-permissions/delete-permission/delete-permission.5.x.rb
+++ b/sync/rest/list-permissions/delete-permission/delete-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_lists('MyFirstList')

--- a/sync/rest/list-permissions/delete-permission/delete-permission.6.x.py
+++ b/sync/rest/list-permissions/delete-permission/delete-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-did_delete = client.preview \
-                   .sync \
+did_delete = client.sync \
                    .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                    .sync_lists("MyFirstList") \
                    .sync_list_permissions("bob") \

--- a/sync/rest/list-permissions/delete-permission/delete-permission.7.x.java
+++ b/sync/rest/list-permissions/delete-permission/delete-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.synclist.SyncListPermission;
+import com.twilio.rest.sync.v1.service.synclist.SyncListPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/list-permissions/list-permissions/list-permissions.5.x.cs
+++ b/sync/rest/list-permissions/list-permissions/list-permissions.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncList;
+using Twilio.Rest.Sync.V1.Service.SyncList;
 
 public class Example
 {

--- a/sync/rest/list-permissions/list-permissions/list-permissions.5.x.php
+++ b/sync/rest/list-permissions/list-permissions/list-permissions.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$permissions = $client->preview->sync
+$permissions = $client->sync
     ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
     ->syncLists('MyFirstList')
     ->syncListPermissions

--- a/sync/rest/list-permissions/list-permissions/list-permissions.5.x.rb
+++ b/sync/rest/list-permissions/list-permissions/list-permissions.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_lists('MyFirstList')

--- a/sync/rest/list-permissions/list-permissions/list-permissions.6.x.py
+++ b/sync/rest/list-permissions/list-permissions/list-permissions.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-list_permissions = client.preview \
-                         .sync \
+list_permissions = client.sync \
                          .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                          .sync_lists("MyFirstList") \
                          .sync_list_permissions \

--- a/sync/rest/list-permissions/list-permissions/list-permissions.7.x.java
+++ b/sync/rest/list-permissions/list-permissions/list-permissions.7.x.java
@@ -2,7 +2,7 @@
 
 import com.twilio.Twilio;
 import com.twilio.base.ResourceSet;
-import com.twilio.rest.preview.sync.service.synclist.SyncListPermission;
+import com.twilio.rest.sync.v1.service.synclist.SyncListPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/list-permissions/list-permissions/output/list-permissions.json
+++ b/sync/rest/list-permissions/list-permissions/output/list-permissions.json
@@ -3,20 +3,20 @@
     {
       "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "list_sid": "MyFirstList",
+      "list_sid": "ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "identity": "bob",
       "read": true,
       "write": true,
       "manage": false,
-      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/MyFirstList/Permissions/bob"
+      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
     }
   ],
   "meta": {
     "page": 0,
     "page_size": 50,
-    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/MyFirstList/Permissions?PageSize=50&Page=0",
+    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "previous_page_url": null,
-    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/MyFirstList/Permissions?PageSize=50&Page=0",
+    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "next_page_url": null,
     "key": "permissions"
   }

--- a/sync/rest/list-permissions/retrieve-permission/output/retrieve-permission.json
+++ b/sync/rest/list-permissions/retrieve-permission/output/retrieve-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "list_sid": "MyFirstList",
+  "list_sid": "ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/MyFirstList/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.cs
+++ b/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncList;
+using Twilio.Rest.Sync.V1.Service.SyncList;
 
 public class Example
 {

--- a/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.php
+++ b/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$permission = $client->preview->sync
+$permission = $client->sync
                      ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                      ->syncLists('MyFirstList')
                      ->syncListPermissions('bob')

--- a/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.rb
+++ b/sync/rest/list-permissions/retrieve-permission/retrieve-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_lists('MyFirstList')

--- a/sync/rest/list-permissions/retrieve-permission/retrieve-permission.6.x.py
+++ b/sync/rest/list-permissions/retrieve-permission/retrieve-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-list_permission = client.preview \
-                        .sync \
+list_permission = client.sync \
                         .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                         .sync_lists("MyFirstList") \
                         .sync_list_permissions("bob") \

--- a/sync/rest/list-permissions/retrieve-permission/retrieve-permission.7.x.java
+++ b/sync/rest/list-permissions/retrieve-permission/retrieve-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.synclist.SyncListPermission;
+import com.twilio.rest.sync.v1.service.synclist.SyncListPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/list-permissions/update-permission/output/update-permission.json
+++ b/sync/rest/list-permissions/update-permission/output/update-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "list_sid": "MyFirstList",
+  "list_sid": "ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/MyFirstList/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Lists/ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/list-permissions/update-permission/update-permission.5.x.cs
+++ b/sync/rest/list-permissions/update-permission/update-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncList;
+using Twilio.Rest.Sync.V1.Service.SyncList;
 
 public class Example
 {

--- a/sync/rest/list-permissions/update-permission/update-permission.5.x.php
+++ b/sync/rest/list-permissions/update-permission/update-permission.5.x.php
@@ -9,7 +9,7 @@ $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
 
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->syncLists('MyFirstList')
                  ->syncListPermissions('bob')

--- a/sync/rest/list-permissions/update-permission/update-permission.5.x.rb
+++ b/sync/rest/list-permissions/update-permission/update-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_lists('MyFirstList')

--- a/sync/rest/list-permissions/update-permission/update-permission.6.x.py
+++ b/sync/rest/list-permissions/update-permission/update-permission.6.x.py
@@ -8,8 +8,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-list_permission = client.preview \
-                        .sync \
+list_permission = client.sync \
                         .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                         .sync_lists("MyFirstList") \
                         .sync_list_permissions("bob") \

--- a/sync/rest/list-permissions/update-permission/update-permission.7.x.java
+++ b/sync/rest/list-permissions/update-permission/update-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.synclist.SyncListPermission;
+import com.twilio.rest.sync.v1.service.synclist.SyncListPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/map-permissions/delete-permission/delete-permission.5.x.cs
+++ b/sync/rest/map-permissions/delete-permission/delete-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncMap;
+using Twilio.Rest.Sync.V1.Service.SyncMap;
 
 public class Example
 {

--- a/sync/rest/map-permissions/delete-permission/delete-permission.5.x.php
+++ b/sync/rest/map-permissions/delete-permission/delete-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->syncMaps('Players')
                  ->syncMapPermissions('bob')

--- a/sync/rest/map-permissions/delete-permission/delete-permission.5.x.rb
+++ b/sync/rest/map-permissions/delete-permission/delete-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_maps('Players')

--- a/sync/rest/map-permissions/delete-permission/delete-permission.6.x.py
+++ b/sync/rest/map-permissions/delete-permission/delete-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-did_delete = client.preview \
-                   .sync \
+did_delete = client.sync \
                    .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                    .sync_maps("Players") \
                    .sync_map_permissions("bob") \

--- a/sync/rest/map-permissions/delete-permission/delete-permission.7.x.java
+++ b/sync/rest/map-permissions/delete-permission/delete-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.syncmap.SyncMapPermission;
+import com.twilio.rest.sync.v1.service.syncmap.SyncMapPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/map-permissions/list-permissions/list-permissions.5.x.cs
+++ b/sync/rest/map-permissions/list-permissions/list-permissions.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncMap;
+using Twilio.Rest.Sync.V1.Service.SyncMap;
 
 public class Example
 {

--- a/sync/rest/map-permissions/list-permissions/list-permissions.5.x.php
+++ b/sync/rest/map-permissions/list-permissions/list-permissions.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$permissions = $client->preview->sync
+$permissions = $client->sync
                       ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                       ->syncMaps('Players')
                       ->syncMapPermissions

--- a/sync/rest/map-permissions/list-permissions/list-permissions.5.x.rb
+++ b/sync/rest/map-permissions/list-permissions/list-permissions.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_maps('Players')

--- a/sync/rest/map-permissions/list-permissions/list-permissions.6.x.py
+++ b/sync/rest/map-permissions/list-permissions/list-permissions.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-map_permissions = client.preview \
-                        .sync \
+map_permissions = client.sync \
                         .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                         .sync_maps("Players") \
                         .sync_map_permissions \

--- a/sync/rest/map-permissions/list-permissions/list-permissions.7.x.java
+++ b/sync/rest/map-permissions/list-permissions/list-permissions.7.x.java
@@ -2,7 +2,7 @@
 
 import com.twilio.Twilio;
 import com.twilio.base.ResourceSet;
-import com.twilio.rest.preview.sync.service.syncmap.SyncMapPermission;
+import com.twilio.rest.sync.v1.service.syncmap.SyncMapPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/map-permissions/list-permissions/output/list-permissions.json
+++ b/sync/rest/map-permissions/list-permissions/output/list-permissions.json
@@ -3,20 +3,20 @@
     {
       "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "map_sid": "Players",
+      "map_sid": "MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
       "identity": "bob",
       "read": true,
       "write": true,
       "manage": false,
-      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/Players/Permissions/bob"
+      "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
     }
   ],
   "meta": {
     "page": 0,
     "page_size": 50,
-    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/Players/Permissions?PageSize=50&Page=0",
+    "first_page_url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "previous_page_url": null,
-    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/Players/Permissions?PageSize=50&Page=0",
+    "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions?PageSize=50&Page=0",
     "next_page_url": null,
     "key": "permissions"
   }

--- a/sync/rest/map-permissions/retrieve-permission/output/retrieve-permission.json
+++ b/sync/rest/map-permissions/retrieve-permission/output/retrieve-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "map_sid": "Players",
+  "map_sid": "MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/Players/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.cs
+++ b/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncMap;
+using Twilio.Rest.Sync.V1.Service.SyncMap;
 
 public class Example
 {

--- a/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.php
+++ b/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$permission = $client->preview->sync
+$permission = $client->sync
                      ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                      ->syncMaps('Players')
                      ->syncMapPermissions('bob')

--- a/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.rb
+++ b/sync/rest/map-permissions/retrieve-permission/retrieve-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_maps('Players')

--- a/sync/rest/map-permissions/retrieve-permission/retrieve-permission.6.x.py
+++ b/sync/rest/map-permissions/retrieve-permission/retrieve-permission.6.x.py
@@ -6,8 +6,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-map_permission = client.preview \
-                       .sync \
+map_permission = client.sync \
                        .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                        .sync_maps("Players") \
                        .sync_map_permissions("bob") \

--- a/sync/rest/map-permissions/retrieve-permission/retrieve-permission.7.x.java
+++ b/sync/rest/map-permissions/retrieve-permission/retrieve-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.syncmap.SyncMapPermission;
+import com.twilio.rest.sync.v1.service.syncmap.SyncMapPermission;
 
 import java.net.URISyntaxException;
 

--- a/sync/rest/map-permissions/update-permission/output/update-permission.json
+++ b/sync/rest/map-permissions/update-permission/output/update-permission.json
@@ -1,10 +1,10 @@
 {
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "map_sid": "Players",
+  "map_sid": "MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "identity": "bob",
   "read": true,
   "write": true,
   "manage": false,
-  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/Players/Permissions/bob"
+  "url": "https://sync.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Maps/MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Permissions/bob"
 }

--- a/sync/rest/map-permissions/update-permission/update-permission.5.x.cs
+++ b/sync/rest/map-permissions/update-permission/update-permission.5.x.cs
@@ -3,7 +3,7 @@ using System;
 using Newtonsoft.Json;
 using Twilio;
 using Twilio.Exceptions;
-using Twilio.Rest.Preview.Sync.Service.SyncMap;
+using Twilio.Rest.Sync.V1.Service.SyncMap;
 
 public class Example
 {

--- a/sync/rest/map-permissions/update-permission/update-permission.5.x.php
+++ b/sync/rest/map-permissions/update-permission/update-permission.5.x.php
@@ -7,7 +7,7 @@ $accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 $authToken = 'your_auth_token';
 
 $client = new Client($accountSid, $authToken);
-$status = $client->preview->sync
+$status = $client->sync
                  ->services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                  ->syncMaps('Players')
                  ->syncMapPermissions('bob')

--- a/sync/rest/map-permissions/update-permission/update-permission.5.x.rb
+++ b/sync/rest/map-permissions/update-permission/update-permission.5.x.rb
@@ -4,7 +4,7 @@ accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 authToken = 'your_auth_token'
 
 client = Twilio::REST::Client.new(accountSid, authToken)
-service = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+service = client.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
 
 begin
   response = service.sync_maps('Players')

--- a/sync/rest/map-permissions/update-permission/update-permission.6.x.py
+++ b/sync/rest/map-permissions/update-permission/update-permission.6.x.py
@@ -8,8 +8,7 @@ account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-map_permission = client.preview \
-                       .sync \
+map_permission = client.sync \
                        .services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") \
                        .sync_maps("Players") \
                        .sync_map_permissions("bob") \

--- a/sync/rest/map-permissions/update-permission/update-permission.7.x.java
+++ b/sync/rest/map-permissions/update-permission/update-permission.7.x.java
@@ -1,7 +1,7 @@
 // Install the Java helper library from twilio.com/docs/libraries/java
 
 import com.twilio.Twilio;
-import com.twilio.rest.preview.sync.service.syncmap.SyncMapPermission;
+import com.twilio.rest.sync.v1.service.syncmap.SyncMapPermission;
 
 import java.net.URISyntaxException;
 


### PR DESCRIPTION
- Switch new permission snippets to sync.twilio.com endpoint, so we'd have consistent state, further switchable via #339
- Update JSON output to always use SIDs for document/list/map_sid and resulting URLs -- according to API specification.