### PR TITLE
Fixing accounts resource

### DIFF
--- a/rest/accounts/instance-get-example-1/instance-get-example-1.3.x.js
+++ b/rest/accounts/instance-get-example-1/instance-get-example-1.3.x.js
@@ -5,6 +5,6 @@ const authToken = 'your_auth_token';
 
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+client.api.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
   .fetch()
   .then((account) => console.log(account.dateCreated));

--- a/rest/accounts/instance-get-example-1/instance-get-example-1.5.x.php
+++ b/rest/accounts/instance-get-example-1/instance-get-example-1.5.x.php
@@ -13,7 +13,7 @@ $client = new Client($sid, $token);
 // You can call $client->account to access the authenticated account
 // you used to initialize the client.
 // Use $client->account->fetch() to get the instance
-$account = $client
+$account = $client->api
     ->accounts("ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->fetch();
 

--- a/rest/accounts/instance-post-example-1/instance-post-example-1.3.x.js
+++ b/rest/accounts/instance-post-example-1/instance-post-example-1.3.x.js
@@ -4,6 +4,6 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+client.api.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
   .update({status: 'suspended'})
   .then((account) => console.log(account.dateCreated));

--- a/rest/accounts/instance-post-example-1/instance-post-example-1.5.x.php
+++ b/rest/accounts/instance-post-example-1/instance-post-example-1.5.x.php
@@ -12,7 +12,7 @@ $client = new Client($sid, $token);
 // check out the list resource examples on this page
 // You can call $client->account to access the authenticated account
 // you used to initialize the client and call update() on that object.
-$account = $client
+$account = $client->api
     ->accounts("ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->update(
         array('status' => 'suspended')

--- a/rest/accounts/instance-post-example-2/instance-post-example-2.3.x.js
+++ b/rest/accounts/instance-post-example-2/instance-post-example-2.3.x.js
@@ -4,6 +4,6 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+client.api.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
   .update({status: 'active'})
   .then((account) => console.log(account.status));

--- a/rest/accounts/instance-post-example-2/instance-post-example-2.5.x.php
+++ b/rest/accounts/instance-post-example-2/instance-post-example-2.5.x.php
@@ -12,7 +12,7 @@ $client = new Client($sid, $token);
 // check out the list resource examples on this page
 // You can call $client->account to access the authenticated account
 // you used to initialize the client and call update() on that object.
-$account = $client
+$account = $client->api
     ->accounts("ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->update(
         array('status' => 'active')

--- a/rest/accounts/instance-post-example-3/instance-post-example-3.3.x.js
+++ b/rest/accounts/instance-post-example-3/instance-post-example-3.3.x.js
@@ -5,6 +5,6 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+client.api.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
   .update({status: 'closed'})
   .then((account) => console.log(account.dateCreated));

--- a/rest/accounts/instance-post-example-3/instance-post-example-3.5.x.php
+++ b/rest/accounts/instance-post-example-3/instance-post-example-3.5.x.php
@@ -12,7 +12,7 @@ $client = new Client($sid, $token);
 // check out the list resource examples on this page
 // You can call $client->account to access the authenticated account
 // you used to initialize the client and call update() on that object.
-$account = $client
+$account = $client->api
     ->accounts("ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->update(
         array('status' => 'closed')

--- a/rest/accounts/list-get-example-1/list-get-example-1.3.x.js
+++ b/rest/accounts/list-get-example-1/list-get-example-1.3.x.js
@@ -5,7 +5,7 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts.list()
+client.api.accounts.list()
   .then((data) => {
     return data.forEach((account) => console.log(account.dateCreated));
   });

--- a/rest/accounts/list-get-example-1/list-get-example-1.5.x.php
+++ b/rest/accounts/list-get-example-1/list-get-example-1.5.x.php
@@ -9,6 +9,6 @@ $token = "your_auth_token";
 $client = new Client($sid, $token);
 
 // Loop over the list of accounts and echo a property for each one
-foreach ($client->accounts->read() as $account) {
+foreach ($client->api->accounts->read() as $account) {
     echo $account->dateCreated->format('Y-m-d H:i:s');
 }

--- a/rest/accounts/list-get-example-2/list-get-example-2.3.x.js
+++ b/rest/accounts/list-get-example-2/list-get-example-2.3.x.js
@@ -5,5 +5,5 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts
+client.api.accounts
   .each({status: 'active'}, (account) => console.log(account.friendlyName));

--- a/rest/accounts/list-get-example-2/list-get-example-2.5.x.php
+++ b/rest/accounts/list-get-example-2/list-get-example-2.5.x.php
@@ -8,7 +8,7 @@ $sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 $token = "your_auth_token";
 $client = new Client($sid, $token);
 
-$accounts = $client->accounts->read(
+$accounts = $client->api->accounts->read(
     array('status' => 'active')
 );
 

--- a/rest/subaccounts/creating-subaccounts-example-1/creating-subaccounts-example-1.3.x.js
+++ b/rest/subaccounts/creating-subaccounts-example-1/creating-subaccounts-example-1.3.x.js
@@ -4,5 +4,5 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts.create({friendlyName: 'Submarine'})
+client.api.accounts.create({friendlyName: 'Submarine'})
   .then((account) => process.stdout.write(account.sid));

--- a/rest/subaccounts/creating-subaccounts-example-1/creating-subaccounts-example-1.5.x.php
+++ b/rest/subaccounts/creating-subaccounts-example-1/creating-subaccounts-example-1.5.x.php
@@ -8,7 +8,7 @@ $sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 $token = "your_auth_token";
 $client = new Client($sid, $token);
 
-$account = $client->api->v2010->accounts->create(array(
+$account = $client->api->accounts->create(array(
     'FriendlyName' => 'Submarine'
 ));
 

--- a/rest/subaccounts/exchanging-numbers-example-1/exchanging-numbers-example-1.3.x.js
+++ b/rest/subaccounts/exchanging-numbers-example-1/exchanging-numbers-example-1.3.x.js
@@ -12,9 +12,9 @@ const currentNumberOwnerAccountSid = 'ACyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy';
 const newNumberOwnerAccountSid = 'ACzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
 const phoneNumberSid = 'PNyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy';
 
-client.accounts(currentNumberOwnerAccountSid)
+client.api.accounts(currentNumberOwnerAccountSid)
   .incomingPhoneNumbers(phoneNumberSid)
-  .update({ 
+  .update({
     accountSid: newNumberOwnerAccountSid // specify new account owner
   })
   .then((number) => console.log(number));

--- a/rest/subaccounts/exchanging-numbers-example-1/exchanging-numbers-example-1.5.x.php
+++ b/rest/subaccounts/exchanging-numbers-example-1/exchanging-numbers-example-1.5.x.php
@@ -8,9 +8,9 @@ $sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 $token = "your_auth_token";
 $client = new Client($sid, $token);
 
-// In the case you want to transfer numbers between subaccounts, you need to 
-// know three things - the account SID of the phone number's current owner, 
-// the account SID of the account you'd like to transfer the number to, and 
+// In the case you want to transfer numbers between subaccounts, you need to
+// know three things - the account SID of the phone number's current owner,
+// the account SID of the account you'd like to transfer the number to, and
 // the SID of the phone number you'd like to transfer
 $currentNumberOwnerAccountSid = "ACyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 $newNumberOwnerAccountSid = "ACzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
@@ -18,7 +18,7 @@ $phoneNumberSid = "PNyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
 // Get an object from its sid. If you do not have a sid,
 // check out the list resource examples on this page
-$number = $client->accounts($currentNumberOwnerAccountSid)
+$number = $client->api->accounts($currentNumberOwnerAccountSid)
     ->incomingPhoneNumbers($phoneNumberSid)
     ->update(array("accountSid" => $newNumberOwnerAccountSid));
 

--- a/rest/subaccounts/listing-subaccounts-example-1/listing-subaccounts-example-1.3.x.js
+++ b/rest/subaccounts/listing-subaccounts-example-1/listing-subaccounts-example-1.3.x.js
@@ -4,6 +4,6 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+client.api.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
   .fetch()
   .then((account) => console.log(account.status));

--- a/rest/subaccounts/listing-subaccounts-example-1/listing-subaccounts-example-1.5.x.php
+++ b/rest/subaccounts/listing-subaccounts-example-1/listing-subaccounts-example-1.5.x.php
@@ -12,6 +12,6 @@ $subAccountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 
 // Get an object from its sid. If you do not have a sid,
 // check out the list resource examples on this page
-$account = $client->accounts($subAccountSid)->fetch();
+$account = $client->api->accounts($subAccountSid)->fetch();
 
 echo $account->status;

--- a/rest/subaccounts/listing-subaccounts-example-2/listing-subaccounts-example-2.3.x.js
+++ b/rest/subaccounts/listing-subaccounts-example-2/listing-subaccounts-example-2.3.x.js
@@ -4,5 +4,5 @@ const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';
 const client = require('twilio')(accountSid, authToken);
 
-client.accounts.each({friendlyName: 'MySubaccount'},
+client.api.accounts.each({friendlyName: 'MySubaccount'},
                      (account) => console.log(account.status));

--- a/rest/subaccounts/listing-subaccounts-example-2/listing-subaccounts-example-2.5.x.php
+++ b/rest/subaccounts/listing-subaccounts-example-2/listing-subaccounts-example-2.5.x.php
@@ -8,7 +8,7 @@ $sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 $token = "your_auth_token";
 $client = new Client($sid, $token);
 
-$accounts = $client->accounts->read(
+$accounts = $client->api->accounts->read(
     array("friendlyName" => "MySubaccount")
 );
 // Loop over the list of accounts and echo a property for each one


### PR DESCRIPTION
Any Node.js, PHP, Python, and Ruby snippets that access the Account resource, like the snippets on this page: https://www.twilio.com/docs/api/rest/account
Need to be updated to use the full api namespace (e.g. `client.api.v2010.accounts` instead of `client.accounts`).
See this issue for background:
https://github.com/twilio/twilio-node/issues/251