### PR TITLE
Remove json_encode from Sync PHP snippets

### DIFF
--- a/sync/rest/documents/create-document/create-document.php
+++ b/sync/rest/documents/create-document/create-document.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'dateUpdated' => date("c"),
     'movieTitle' => "On The Line",
     'showtimes' => array("12:30:00Z", "14:45:00Z", "15:30:00Z", "17:45:00Z", "20:30:00Z"),
@@ -26,7 +26,7 @@ $doc = $client->sync
     ->documents->create(
         array(
             'uniqueName' => "MyFirstDocument",
-            'data' => json_encode($data)
+            'data' => $data
         )
     );
 

--- a/sync/rest/documents/update-document/update-document.php
+++ b/sync/rest/documents/update-document/update-document.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'dateUpdated' => date("c"),
     'movieTitle' => "On The Line",
     'showtimes' => null,
@@ -25,7 +25,7 @@ $doc = $client->sync
     ->services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->documents("MyFirstDocument")->update(
         array(
-            'data' => json_encode($data)
+            'data' => $data
         )
     );
 

--- a/sync/rest/lists/create-list-item/create-list-item.php
+++ b/sync/rest/lists/create-list-item/create-list-item.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'number' => "001",
     'name' => "Bulbasaur",
     'attack' => 49
@@ -24,7 +24,7 @@ $item = $client->sync
     ->syncLists("MyCollection")
     ->syncListItems->create(
         array(
-            'data' => json_encode($data)
+            'data' => $data
         )
     );
 

--- a/sync/rest/lists/update-list-item/update-list-item.php
+++ b/sync/rest/lists/update-list-item/update-list-item.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'number' => "001",
     'name' => "Bulbasaur",
     'attack' => 50
@@ -24,7 +24,7 @@ $item = $client->sync
     ->syncLists("MyCollection")
     ->syncListItems(0)->update(
         array(
-            'data' => json_encode($data)
+            'data' => $data
         )
     );
 

--- a/sync/rest/maps/create-map-item/create-map-item.php
+++ b/sync/rest/maps/create-map-item/create-map-item.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'name' => "Stephen Curry",
     'level' => 30,
     'username' => "spicy_curry"
@@ -23,7 +23,7 @@ $item = $client->sync
     ->services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->syncMaps("Players")
     ->syncMapItems->create(
-        'steph_curry', json_encode($data)
+        'steph_curry', $data
     );
 
 print_r($item->data);

--- a/sync/rest/maps/update-map-item/update-map-item.php
+++ b/sync/rest/maps/update-map-item/update-map-item.php
@@ -13,7 +13,7 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$data = (object) array(
+$data = array(
     'name' => "Stephen Curry",
     'level' => 31,
     'username' => "spicy_curry"
@@ -22,7 +22,7 @@ $data = (object) array(
 $item = $client->sync
     ->services("ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->syncMaps("Players")
-    ->syncMapItems("steph_curry")->update(json_encode($data));
+    ->syncMapItems("steph_curry")->update($data);
 
 print_r($item->data);
 echo PHP_EOL;


### PR DESCRIPTION
`json_encode` is no longer necessary after https://github.com/TwilioDevEd/sdk-starter-php/pull/17