### PR TITLE
remove messages key

### DIFF
--- a/rest/message/list-get-example-1/list-get-example-1.2.x.js
+++ b/rest/message/list-get-example-1/list-get-example-1.2.x.js
@@ -5,7 +5,7 @@ var authToken = "your_auth_token";
 var client = require('twilio')(accountSid, authToken);
 
 client.messages.list(function(err, data) {
-    data.messages.forEach(function(message) {
+    data.forEach(function(message) {
         console.log(message.body);
     });
 });


### PR DESCRIPTION
When I query this via the nodejs library the data returned doesn't come within a nested `messages` key, it's just directly in the result. 

```
client.messages.list((err, data) =>{
  if (err) { console.error(err); }
  if (data) {
    data.forEach(message => console.log(message))
  }
})
```