### PR TITLE
Adds url encoding to Notify Create Binding curl example

### DIFF
--- a/notifications/rest/bindings/create-binding/create-binding.json.curl
+++ b/notifications/rest/bindings/create-binding/create-binding.json.curl
@@ -1,8 +1,8 @@
 curl -XPOST https://notify.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Bindings \
-    -d "Endpoint=endpoint_id" \
-    -d "Identity=00000001" \
-    -d "BindingType=apn" \
-    -d "Address=device_token" \
-    -d "Tag=preferred device" \
-    -d "Tag=new user" \
+    --data-urlencode "Endpoint=endpoint_id" \
+    --data-urlencode "Identity=00000001" \
+    --data-urlencode "BindingType=apn" \
+    --data-urlencode "Address=device_token" \
+    --data-urlencode "Tag=preferred device" \
+    --data-urlencode "Tag=new user" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/notifications/rest/bindings/list-binding/list-binding.json.curl
+++ b/notifications/rest/bindings/list-binding/list-binding.json.curl
@@ -1,4 +1,4 @@
 curl -XGET 'https://notify.twilio.com/v1/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Bindings' \
-    -d "StartDate=2017-01-17" \
-    -d "Tag=new user" \
+    --data-urlencode "StartDate=2017-01-17" \
+    --data-urlencode "Tag=new user" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/notifications/rest/credentials/create-fcm-credential/create-fcm-credential.json.curl
+++ b/notifications/rest/credentials/create-fcm-credential/create-fcm-credential.json.curl
@@ -1,5 +1,5 @@
 curl -XPOST https://notify.twilio.com/v1/Credentials \
-    -d "FriendlyName=MyFCMCredential" \
-    -d "Type=fcm" \
-    -d "Secret=fcm_secret" \
+    --data-urlencode "FriendlyName=MyFCMCredential" \
+    --data-urlencode "Type=fcm" \
+    --data-urlencode "Secret=fcm_secret" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/notifications/rest/credentials/create-gcm-credential/create-gcm-credential.json.curl
+++ b/notifications/rest/credentials/create-gcm-credential/create-gcm-credential.json.curl
@@ -1,5 +1,5 @@
 curl -XPOST https://notify.twilio.com/v1/Credentials \
-    -d "FriendlyName=MyGCMCredential" \
-    -d "Type=gcm" \
-    -d "ApiKey=gcm_api_key" \
+    --data-urlencode "FriendlyName=MyGCMCredential" \
+    --data-urlencode "Type=gcm" \
+    --data-urlencode "ApiKey=gcm_api_key" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'


### PR DESCRIPTION
Many fields in Create Binding request supports unicode and hence need to be url encoded.