### PR TITLE
Remove references to alpha artifacts

### DIFF
--- a/proxy/quickstart/add-phone-number/add-phone-number.3.x.js
+++ b/proxy/quickstart/add-phone-number/add-phone-number.3.x.js
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/node#accessing-preview-twilio-features
-
 // These consts are your accountSid and authToken from https://www.twilio.com/console
 const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';

--- a/proxy/quickstart/add-phone-number/add-phone-number.5.x.cs
+++ b/proxy/quickstart/add-phone-number/add-phone-number.5.x.cs
@@ -1,6 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/csharp#accessing-preview-twilio-features
 using System;
 using Twilio;
 using Twilio.Rest.Preview.Proxy.Service;

--- a/proxy/quickstart/add-phone-number/add-phone-number.5.x.php
+++ b/proxy/quickstart/add-phone-number/add-phone-number.5.x.php
@@ -1,7 +1,4 @@
 <?php
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/php#accessing-preview-twilio-features
 
 // This line loads the library
 require './vendor/autoload.php';

--- a/proxy/quickstart/add-phone-number/add-phone-number.5.x.rb
+++ b/proxy/quickstart/add-phone-number/add-phone-number.5.x.rb
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/ruby#installation-nextgen
 require 'twilio-ruby'
 
 # Get your Account SID and Auth Token from twilio.com/console

--- a/proxy/quickstart/add-phone-number/add-phone-number.6.x.py
+++ b/proxy/quickstart/add-phone-number/add-phone-number.6.x.py
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/python#accessing-preview-twilio-features
 from twilio.rest import Client
 
 # Account SID and Auth Token are found in the console:

--- a/proxy/quickstart/add-phone-number/add-phone-number.7.x.java
+++ b/proxy/quickstart/add-phone-number/add-phone-number.7.x.java
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/java#accessing-preview-twilio-features
-
 import com.twilio.Twilio;
 import com.twilio.rest.preview.proxy.service.PhoneNumber;
 

--- a/proxy/quickstart/create-participant/create-participant.3.x.js
+++ b/proxy/quickstart/create-participant/create-participant.3.x.js
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/node#accessing-preview-twilio-features
-
 // These consts are your accountSid and authToken from https://www.twilio.com/console
 const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';

--- a/proxy/quickstart/create-participant/create-participant.5.x.cs
+++ b/proxy/quickstart/create-participant/create-participant.5.x.cs
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/csharp#accessing-preview-twilio-features
-
 using System;
 using Twilio;
 using Twilio.Rest.Preview.Proxy.Service.Session;

--- a/proxy/quickstart/create-participant/create-participant.5.x.php
+++ b/proxy/quickstart/create-participant/create-participant.5.x.php
@@ -1,7 +1,4 @@
 <?php
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/php#accessing-preview-twilio-features
 
 // This line loads the library
 require './vendor/autoload.php';

--- a/proxy/quickstart/create-participant/create-participant.5.x.rb
+++ b/proxy/quickstart/create-participant/create-participant.5.x.rb
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/ruby#installation-nextgen
 require 'twilio-ruby'
 
 # Get your Account SID and Auth Token from twilio.com/console

--- a/proxy/quickstart/create-participant/create-participant.6.x.py
+++ b/proxy/quickstart/create-participant/create-participant.6.x.py
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/python#accessing-preview-twilio-features
 from twilio.rest import Client
 
 # Account SID and Auth Token are found in the console:

--- a/proxy/quickstart/create-participant/create-participant.7.x.java
+++ b/proxy/quickstart/create-participant/create-participant.7.x.java
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/java#accessing-preview-twilio-features
-
 import com.twilio.Twilio;
 import com.twilio.rest.preview.proxy.service.session.Participant;
 

--- a/proxy/quickstart/create-service/create-service.3.x.js
+++ b/proxy/quickstart/create-service/create-service.3.x.js
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/node#accessing-preview-twilio-features
-
 // These consts are your accountSid and authToken from https://www.twilio.com/console
 const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';

--- a/proxy/quickstart/create-service/create-service.5.x.cs
+++ b/proxy/quickstart/create-service/create-service.5.x.cs
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/csharp#accessing-preview-twilio-features
-
 using System;
 using Twilio;
 using Twilio.Rest.Preview.Proxy;

--- a/proxy/quickstart/create-service/create-service.5.x.php
+++ b/proxy/quickstart/create-service/create-service.5.x.php
@@ -1,7 +1,4 @@
 <?php
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/php#accessing-preview-twilio-features
 
 // This line loads the library
 require './vendor/autoload.php';

--- a/proxy/quickstart/create-service/create-service.5.x.rb
+++ b/proxy/quickstart/create-service/create-service.5.x.rb
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/ruby#installation-nextgen
 require 'twilio-ruby'
 
 # Get your Account SID and Auth Token from twilio.com/console

--- a/proxy/quickstart/create-service/create-service.6.x.py
+++ b/proxy/quickstart/create-service/create-service.6.x.py
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/python#accessing-preview-twilio-features
 from twilio.rest import Client
 
 # Account SID and Auth Token are found in the console:

--- a/proxy/quickstart/create-service/create-service.7.x.java
+++ b/proxy/quickstart/create-service/create-service.7.x.java
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/java#accessing-preview-twilio-features
-
 import com.twilio.Twilio;
 import com.twilio.rest.preview.proxy.Service;
 

--- a/proxy/quickstart/create-session/create-session.3.x.js
+++ b/proxy/quickstart/create-session/create-session.3.x.js
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/node#accessing-preview-twilio-features
-
 // These consts are your accountSid and authToken from https://www.twilio.com/console
 const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';

--- a/proxy/quickstart/create-session/create-session.5.x.cs
+++ b/proxy/quickstart/create-session/create-session.5.x.cs
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/csharp#accessing-preview-twilio-features
-
 using System;
 using Twilio;
 using Twilio.Rest.Preview.Proxy.Service;

--- a/proxy/quickstart/create-session/create-session.5.x.php
+++ b/proxy/quickstart/create-session/create-session.5.x.php
@@ -1,7 +1,4 @@
 <?php
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/php#accessing-preview-twilio-features
 
 // This line loads the library
 require './vendor/autoload.php';

--- a/proxy/quickstart/create-session/create-session.5.x.rb
+++ b/proxy/quickstart/create-session/create-session.5.x.rb
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/ruby#installation-nextgen
 require 'twilio-ruby'
 
 # Get your Account SID and Auth Token from twilio.com/console

--- a/proxy/quickstart/create-session/create-session.6.x.py
+++ b/proxy/quickstart/create-session/create-session.6.x.py
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/python#accessing-preview-twilio-features
 from twilio.rest import Client
 
 # Account SID and Auth Token are found in the console:

--- a/proxy/quickstart/create-session/create-session.7.x.java
+++ b/proxy/quickstart/create-session/create-session.7.x.java
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/java#accessing-preview-twilio-features
-
 import com.twilio.Twilio;
 import com.twilio.rest.preview.proxy.service.Session;
 

--- a/proxy/quickstart/send-message/send-message.3.x.js
+++ b/proxy/quickstart/send-message/send-message.3.x.js
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/node#accessing-preview-twilio-features
-
 // These consts are your accountSid and authToken from https://www.twilio.com/console
 const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 const authToken = 'your_auth_token';

--- a/proxy/quickstart/send-message/send-message.5.x.cs
+++ b/proxy/quickstart/send-message/send-message.5.x.cs
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/csharp#accessing-preview-twilio-features
-
 using System;
 using Twilio;
 using Twilio.Rest.Preview.Proxy.Service.Session.Participant;

--- a/proxy/quickstart/send-message/send-message.5.x.php
+++ b/proxy/quickstart/send-message/send-message.5.x.php
@@ -1,7 +1,4 @@
 <?php
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/php#accessing-preview-twilio-features
 
 // This line loads the library
 require './vendor/autoload.php';

--- a/proxy/quickstart/send-message/send-message.5.x.rb
+++ b/proxy/quickstart/send-message/send-message.5.x.rb
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/ruby#installation-nextgen
 require 'twilio-ruby'
 
 # Get your Account SID and Auth Token from twilio.com/console

--- a/proxy/quickstart/send-message/send-message.6.x.py
+++ b/proxy/quickstart/send-message/send-message.6.x.py
@@ -1,6 +1,3 @@
-# NOTE: This example uses the ALPHA release of the next generation Twilio
-# helper library - for more information on how to download and install this version, visit
-# https://www.twilio.com/docs/libraries/python#accessing-preview-twilio-features
 from twilio.rest import Client
 
 # Account SID and Auth Token are found in the console:

--- a/proxy/quickstart/send-message/send-message.7.x.java
+++ b/proxy/quickstart/send-message/send-message.7.x.java
@@ -1,7 +1,3 @@
-// NOTE: This example uses the ALPHA release of the next generation Twilio
-// helper library - for more information on how to download and install this version, visit
-// https://www.twilio.com/docs/libraries/java#accessing-preview-twilio-features
-
 import com.twilio.Twilio;
 import com.twilio.rest.preview.proxy.service.session.participant.MessageInteraction;
 


### PR DESCRIPTION
The alpha artifact is being rolled into the normal artifact, so these warnings no longer need to exist.