### PR TITLE
Add missing comma in JSON

### DIFF
--- a/rest/incoming-phone-numbers/instance-get-example-1/output/instance-get-example-1.json
+++ b/rest/incoming-phone-numbers/instance-get-example-1/output/instance-get-example-1.json
@@ -23,7 +23,7 @@
     "sms": true,
     "mms": false
   },
-  "beta": false
+  "beta": false,
   "api_version": "2010-04-01",
   "uri": "\/2010-04-01\/Accounts\/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\/IncomingPhoneNumbers\/PN2a0747eba6abf96b7e3c3ff0b4530f6e.json"
 }


### PR DESCRIPTION
Noticed there was a missing comma in the code example for `incomingPhoneNumber` resource response. Fixed it!