### PR TITLE
Add an option that modifies the hosts file for testing only

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,28 @@ the wrong user.
    directory of the fake-api repo. Go [here](https://support.apple.com/kb/PH18677?locale=en_US)
    for more information.
 
+
 1. Update your hosts file with [this content](./tools/hosts)
 
    ```bash
    sudo cat ./tools/hosts >> /etc/hosts
    ```
+
+   If you want to avoid this step, you can simply pass the option `-u` to the
+   test runner.
+
+   ```bash
+   SNIPPET_LANGUAGE=node ruby tools/snippet-testing/snippet_tester.rb -u -d rest/calls
+   ```
+
+   **Note:** To make changes inside the `/etc/hosts` file, it will prompt you
+   for your password.
+
+   **Note:** For Mac users, this options depends on gnu `sed` command, because mac
+   native `sed` has problems when using optiong `-i`, for that reason I suggest
+   you to install `brew install gnu-sed` and create an alias in your `.bashrc`
+   file like `alias sed=gsed`.
+
 
 1. Make a copy of the `.env.example` file.
 

--- a/README.md
+++ b/README.md
@@ -309,12 +309,6 @@ the wrong user.
    **Note:** To make changes inside the `/etc/hosts` file, it will prompt you
    for your password.
 
-   **Note:** For Mac users, this options depends on gnu `sed` command, because mac
-   native `sed` has problems when using optiong `-i`, for that reason I suggest
-   you to install `brew install gnu-sed` and create an alias in your `.bashrc`
-   file like `alias sed=gsed`.
-
-
 1. Make a copy of the `.env.example` file.
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -292,25 +292,10 @@ the wrong user.
    directory of the fake-api repo. Go [here](https://support.apple.com/kb/PH18677?locale=en_US)
    for more information.
 
-1. Change your hosts file.
+1. Change your hosts file
 
-   Edit your `/etc/hosts` file. Add the following entries:
-   ```
-   127.0.0.1 api.twilio.com
-   127.0.0.1 chat.twilio.com
-   127.0.0.1 fax.twilio.com
-   127.0.0.1 ip-messaging.twilio.com
-   127.0.0.1 lookups.twilio.com
-   127.0.0.1 messaging.twilio.com
-   127.0.0.1 monitor.twilio.com
-   127.0.0.1 notifications.twilio.com
-   127.0.0.1 notify.twilio.com
-   127.0.0.1 pricing.twilio.com
-   127.0.0.1 preview.twilio.com
-   127.0.0.1 sync.twilio.com
-   127.0.0.1 taskrouter.twilio.com
-   127.0.0.1 video.twilio.com
-   127.0.0.1 wireless.twilio.com
+   ```bash
+   sudo cat ./tools/hosts >> /etc/hosts
    ```
 
 1. Make a copy of the `.env.example` file.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ the wrong user.
    directory of the fake-api repo. Go [here](https://support.apple.com/kb/PH18677?locale=en_US)
    for more information.
 
-1. Change your hosts file
+1. Update your hosts file with [this content](./tools/hosts)
 
    ```bash
    sudo cat ./tools/hosts >> /etc/hosts

--- a/tools/hosts
+++ b/tools/hosts
@@ -1,4 +1,3 @@
-# START: api-snippets
 127.0.0.1 api.twilio.com
 127.0.0.1 chat.twilio.com
 127.0.0.1 fax.twilio.com
@@ -14,4 +13,3 @@
 127.0.0.1 taskrouter.twilio.com
 127.0.0.1 video.twilio.com
 127.0.0.1 wireless.twilio.com
-# END: api-snippets

--- a/tools/hosts
+++ b/tools/hosts
@@ -1,0 +1,17 @@
+# START: api-snippets
+127.0.0.1 api.twilio.com
+127.0.0.1 chat.twilio.com
+127.0.0.1 fax.twilio.com
+127.0.0.1 ip-messaging.twilio.com
+127.0.0.1 lookups.twilio.com
+127.0.0.1 messaging.twilio.com
+127.0.0.1 monitor.twilio.com
+127.0.0.1 notifications.twilio.com
+127.0.0.1 notify.twilio.com
+127.0.0.1 pricing.twilio.com
+127.0.0.1 preview.twilio.com
+127.0.0.1 sync.twilio.com
+127.0.0.1 taskrouter.twilio.com
+127.0.0.1 video.twilio.com
+127.0.0.1 wireless.twilio.com
+# END: api-snippets

--- a/tools/snippet-testing/snippet_tester.rb
+++ b/tools/snippet-testing/snippet_tester.rb
@@ -74,13 +74,14 @@ class SnippetTester
   end
 
   def add_hosts()
+    remove_hosts()
     Dir.chdir(__dir__) do
       `sudo -- sh -c "cat ../hosts >> /etc/hosts"`
     end
   end
 
   def remove_hosts()
-    `sudo -- sh -c "sed -i '' '/^# START: api-snippets$/,/^# END: api-snippets$/d' /etc/hosts"`
+    `sudo sed -i'' '/^# START: api-snippets$/,/^# END: api-snippets$/d' /etc/hosts`
   end
 
   private
@@ -241,7 +242,7 @@ def parse_options(args)
       options.test_default = true if options.test_default.nil?
     end
 
-    opts.on('-h', 'Append the twilio endpoints to your hosts file for testing') do
+    opts.on('-u', '--update-hosts', 'Update your /etc/hosts file with fake twilio endpoints just for testing') do
       options.update_hosts = true
     end
   end
@@ -256,15 +257,16 @@ if __FILE__ == $0
     tester = SnippetTester.new(options.source_folder, options.test_default)
 
     tester.install_dependencies if options.install
-    tester.add_hosts if options.update_hosts
     tester.run_before_test
     tester.init
     tester.setup
+    tester.add_hosts if options.update_hosts
     tester.run
     tester.remove_hosts if options.update_hosts
 
     print_errors_if_any
   rescue Interrupt
+    tester.remove_hosts if options.update_hosts
     print_errors_if_any
   end
 end

--- a/tools/snippet-testing/snippet_tester.rb
+++ b/tools/snippet-testing/snippet_tester.rb
@@ -74,14 +74,18 @@ class SnippetTester
   end
 
   def add_hosts()
+    @start = "# START: api-snippets"
+    @end = "# END: api-snippets"
+
     remove_hosts()
     Dir.chdir(__dir__) do
-      `sudo -- sh -c "cat ../hosts >> /etc/hosts"`
+      hosts = `cat ../hosts`
+      `sudo -- sh -c 'echo "#{@start}\n#{hosts}\n#{@end}" >> /etc/hosts'`
     end
   end
 
   def remove_hosts()
-    `sudo sed -i'' '/^# START: api-snippets$/,/^# END: api-snippets$/d' /etc/hosts`
+    `sudo sed -i -- "/#{@start}/,/#{@end}/d" /etc/hosts`
   end
 
   private
@@ -262,11 +266,11 @@ if __FILE__ == $0
     tester.setup
     tester.add_hosts if options.update_hosts
     tester.run
-    tester.remove_hosts if options.update_hosts
 
     print_errors_if_any
   rescue Interrupt
-    tester.remove_hosts if options.update_hosts
     print_errors_if_any
+  ensure
+    tester.remove_hosts if options.update_hosts
   end
 end

--- a/tools/snippet-testing/snippet_tester.rb
+++ b/tools/snippet-testing/snippet_tester.rb
@@ -73,6 +73,16 @@ class SnippetTester
     end
   end
 
+  def add_hosts()
+    Dir.chdir(__dir__) do
+      `sudo -- sh -c "cat ../hosts >> /etc/hosts"`
+    end
+  end
+
+  def remove_hosts()
+    `sudo -- sh -c "sed -i '' '/^# START: api-snippets$/,/^# END: api-snippets$/d' /etc/hosts"`
+  end
+
   private
 
   attr_reader :parent_source_folder, :snippets_models, :test_models
@@ -230,6 +240,10 @@ def parse_options(args)
       options.source_folder = File.expand_path(dir)
       options.test_default = true if options.test_default.nil?
     end
+
+    opts.on('-h', 'Append the twilio endpoints to your hosts file for testing') do
+      options.update_hosts = true
+    end
   end
 
   opts.parse!(args)
@@ -242,10 +256,12 @@ if __FILE__ == $0
     tester = SnippetTester.new(options.source_folder, options.test_default)
 
     tester.install_dependencies if options.install
+    tester.add_hosts if options.update_hosts
     tester.run_before_test
     tester.init
     tester.setup
     tester.run
+    tester.remove_hosts if options.update_hosts
 
     print_errors_if_any
   rescue Interrupt


### PR DESCRIPTION
The purpose of this PR is to include an option to the `snippet_tester.rb` that allow it overwrite your `/etc/hosts` file in _test time_, adding/removing fake api endpoints.
So that you have nothing to worry about if you need to work later on with the real endpoints!