### PR TITLE
Add the quickstart snippet for Paho/Python MQTT connection.

### DIFF
--- a/deployed-devices/quickstarts/paho-python/meta.json
+++ b/deployed-devices/quickstarts/paho-python/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "Subscribe to a Document from MQTT in Paho/Python",
+    "type": "server"
+}
+

--- a/deployed-devices/quickstarts/paho-python/subscribe-and-print.py
+++ b/deployed-devices/quickstarts/paho-python/subscribe-and-print.py
@@ -1,0 +1,25 @@
+import paho.mqtt.client as mqtt
+
+#
+# Use the actual location of your downloaded certificate and key.
+#
+pem_location = '/…/CY499a5cbd774f4970a9ab51e2e8c4fb57.pem'
+key_location = '/…/CY499a5cbd774f4970a9ab51e2e8c4fb57.key.decrypted'
+
+client = mqtt.Client(client_id="bob", clean_session=False)
+client.set_tls(None, pem_location, key_location)
+
+#
+# Print out any updates.
+#
+def print_message(client, userdata, msg):
+    print(msg.topic + ' ' + str(msg.payload))
+
+client.on_message = print_message
+
+#
+# Use qos=1 to get your device caught up right away.
+#
+client.connect('mqtt-sync.us1.twilio.com', 8883, 60)
+client.subscribe('sync/docs/MyDoc', qos=1)
+client.loop_forever()


### PR DESCRIPTION
This will replace the inline code block [here](https://www.twilio.com/docs/quickstart/python-mqtt-quickstart#subscribe-to-the-sync-document-from-mqtt).

I'm actually concerned that the file extension doesn't match the constraints of Wagtail. This snippet does not use the helper library, so mentioning a version number would be nonsense.