### PR TITLE
Corrects video dowloading example code

### DIFF
--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.3.x.js
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.3.x.js
@@ -11,9 +11,9 @@ const client = new Twilio(apiKeySid, apiKeySecret, { accountSid: accountSid });
 
 const recordingSid = "RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 const uri = `https://video.twilio.com/v1/Recordings/${recordingSid}/Media`;
-const response = client.request({ method: "POST", uri: uri });
-const mediaLocation = JSON.parse(response.body).location;
-
-request.get(mediaLocation, (err, res, media) => {
-  console.log(media);
+client.request({ method: "GET", uri: uri }).then(response => {
+  const mediaLocation = JSON.parse(response.body).location;
+  request.get(mediaLocation, (err, res, media) => {
+    console.log(media);
+  });
 });


### PR DESCRIPTION
This fixes a couple of issues with this sample, as discovered in this [Stack Overflow question](https://stackoverflow.com/questions/46588223/issue-downloading-twilio-recording-in-twilio-rooms).

* `client.request` returns a promise rather than running synchronously
* requesting a media resource should be by `GET` not `POST`