### PR TITLE
Add request validation for C# .NET Core

### DIFF
--- a/guides/request-validation-csharp-core/example-1/example-1.4.x.cs
+++ b/guides/request-validation-csharp-core/example-1/example-1.4.x.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using Twilio.Security;
+
+namespace ValidateRequestExample.Filters
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ValidateTwilioRequestAttribute : ActionFilterAttribute
+    {
+        private readonly RequestValidator _requestValidator;
+
+        private static IConfigurationRoot Configuration =>
+            new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", true, true).Build();
+
+        public ValidateTwilioRequestAttribute()
+        {
+            var authToken = Configuration["TwilioAuthToken"];
+            _requestValidator = new RequestValidator(authToken);
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext actionContext)
+        {
+            var context = actionContext.HttpContext;
+            if (!IsValidRequest(context.Request))
+            {
+                actionContext.HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+
+        private bool IsValidRequest(HttpRequest request) {
+            var requestUrl = RequestRawUrl(request);
+            var parameters = ToDictionary(request.Form);
+            var signature = request.Headers["X-Twilio-Signature"];
+            return _requestValidator.Validate(requestUrl, parameters, signature);
+        }
+
+        private static string RequestRawUrl(HttpRequest request)
+        {
+            return $"{request.Scheme}://{request.Host}{request.Path}{request.QueryString}";
+        }
+
+        private static IDictionary<string, string> ToDictionary(IFormCollection collection)
+        {
+            return collection.Keys
+                .Select(key => new { Key = key, Value = collection[key] })
+                .ToDictionary(p => p.Key, p => p.Value.ToString());
+        }
+    }
+}

--- a/guides/request-validation-csharp-core/example-1/meta.json
+++ b/guides/request-validation-csharp-core/example-1/meta.json
@@ -1,0 +1,5 @@
+{
+  "type": "server",
+  "description": "Confirm incoming requests to your controllers are genuine with this filter.",
+  "title": "Use filter attribute to validate Twilio requests"
+}

--- a/guides/request-validation-csharp-core/example-2/example-2.4.x.cs
+++ b/guides/request-validation-csharp-core/example-2/example-2.4.x.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Twilio.TwiML;
+using ValidateRequestExample.Filters;
+
+namespace ValidateRequestExample.Controllers
+{
+    public class IncomingController : Controller
+    {
+        [ValidateTwilioRequest]
+        [Produces("text/xml")]
+        public IActionResult Voice(string from)
+        {
+            var message = "Thanks for calling! " +
+                $"Your phone number is {from}. " +
+                "I got your call because of Twilio\'s webhook. "  +
+                "Goodbye!";
+
+            var response = new VoiceResponse();
+            response.Say(string.Format(message, from));
+            response.Hangup();
+
+            return Content(response.ToString());
+        }
+
+        [ValidateTwilioRequest]
+        [Produces("text/xml")]
+        public IActionResult Message(string body)
+        {
+            var message = $"Your text to me was {body.Length} characters long. " +
+                            "Webhooks are neat :)";
+
+            var response = new MessagingResponse();
+            response.Message(new Message(message));
+
+            return Content(response.ToString());
+        }
+    }
+}

--- a/guides/request-validation-csharp-core/example-2/meta.json
+++ b/guides/request-validation-csharp-core/example-2/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Apply the request validation filter attribute to a set of controller methods",
+  "description": "Apply a custom Twilio request validation filter attribute to a set of controller methods used for Twilio webhooks.",
+  "type": "server"
+}

--- a/guides/request-validation-csharp-core/example-3/example-3.4.x.cs
+++ b/guides/request-validation-csharp-core/example-3/example-3.4.x.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using Twilio.Security;
+
+namespace ValidateRequestExample.Filters
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ValidateTwilioRequestAttribute : ActionFilterAttribute
+    {
+        private readonly RequestValidator _requestValidator;
+        private static IConfigurationRoot Configuration =>
+            new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", true, true).Build();
+        private static bool IsTestEnvironment =>
+            bool.Parse(Configuration["IsTestEnvironment"]);
+
+        public ValidateTwilioRequestAttribute()
+        {
+            var authToken = Configuration["TwilioAuthToken"];
+            _requestValidator = new RequestValidator(authToken);
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext actionContext)
+        {
+            var context = actionContext.HttpContext;
+            if (!IsValidRequest(context.Request) || !IsTestEnvironment)
+            {
+                actionContext.HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+
+
+        private bool IsValidRequest(HttpRequest request) {
+            var requestUrl = RequestRawUrl(request);
+            var parameters = ToDictionary(request.Form);
+            var signature = request.Headers["X-Twilio-Signature"];
+            return _requestValidator.Validate(requestUrl, parameters, signature);
+        }
+
+        private static string RequestRawUrl(HttpRequest request)
+        {
+            return $"{request.Scheme}://{request.Host}{request.Path}{request.QueryString}";
+        }
+
+        private static IDictionary<string, string> ToDictionary(IFormCollection collection)
+        {
+            return collection.Keys
+                .Select(key => new { Key = key, Value = collection[key] })
+                .ToDictionary(p => p.Key, p => p.Value.ToString());
+        }
+    }
+}

--- a/guides/request-validation-csharp-core/example-3/meta.json
+++ b/guides/request-validation-csharp-core/example-3/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "An improved request validation filter attribute, useful for testing",
+  "description": "Use this version of the custom filter attribute if you test your controllers.",
+  "type": "server"
+}


### PR DESCRIPTION
The examples in this pull request will be used in the tutorial **Secure your C# / ASP.NET Core App by Validating Incoming Twilio Requests**.