### PR TITLE
Corrects video downloading examples

### DIFF
--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.cs
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.cs
@@ -1,12 +1,14 @@
 // Download the twilio-csharp library from twilio.com/docs/libraries/csharp
 using System;
+using System.Collections.Generic;
 using System.Net;
+using Newtonsoft.Json;
 using Twilio;
 using Twilio.Http;
 
 class Example
 {
-    static void Main (string[] args)
+    static void Main(string[] args)
     {
         // Find your Account SID and Auth Token at twilio.com/console
         const string apiKeySid = "SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
@@ -14,13 +16,15 @@ class Example
         TwilioClient.Init(apiKeySid, apiKeySecret);
 
         const string recordingSid = "RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-        const string uri = $"https://video.twilio.com/v1/Recordings/{recordingSid}/Media";
+        var uri = $"https://video.twilio.com/v1/Recordings/{recordingSid}/Media";
         var response = TwilioClient.GetRestClient().Request(new Request(HttpMethod.Get, uri));
-        var media_location = JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content)["location"];
+        var mediaLocation =
+            JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content)["location"];
 
-        using(var webClient = new WebClient()) {
-            string media_content = webClient.DownloadString(media_location);
-            Console.WriteLine(media_content);
+        using (var webClient = new WebClient())
+        {
+            string mediaContent = webClient.DownloadString(mediaLocation);
+            Console.WriteLine(mediaContent);
         }
     }
 }

--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.php
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.php
@@ -5,12 +5,12 @@ use Twilio\Rest\Client;
 
 // Your Account Sid and Auth Token from twilio.com/console
 $apiKeySid = "SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-$apiKeySecret = "your_auth_apiKeySecret";
+$apiKeySecret = "your_auth_api_key_secret";
 $client = new Client($apiKeySid, $apiKeySecret);
 
 $recordingSid = "RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
 $uri = "https://video.twilio.com/v1/Recordings/$recordingSid/Media";
-$response = $client->request("POST", $uri);
+$response = $client->request("GET", $uri);
 $mediaLocation = json_decode($response->content)["location"];
 
 $media_content = file_get_contents($mediaLocation);

--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.rb
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.5.x.rb
@@ -10,7 +10,7 @@ client = Twilio::REST::Client.new(api_key_sid, api_key_secret)
 
 recording_sid = 'RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 uri = "https://video.twilio.com/v1/Recordings/#{recording_sid}/Media"
-response = client.request(method: 'POST', uri: uri)
+response = client.request(method: 'GET', uri: uri)
 media_location = JSON.parse(response.body)['location']
 
 media_content = Net::HTTP.get(URI(media_location))

--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.6.x.py
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.6.x.py
@@ -11,7 +11,7 @@ client = Client(api_key_sid, api_key_secret)
 
 recording_sid = "RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 uri = "https://video.twilio.com/v1/Recordings/{}/Media".format(recording_sid)
-response = client.request("POST", uri)
+response = client.request("GET", uri)
 media_location = json.loads(response.text).get("location")
 
 media_content = urllib2.urlopen(media_location).read()

--- a/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.7.x.java
+++ b/video/rest/recordings/retrieve-recording-binary-data/retrieve-recording-binary-data.7.x.java
@@ -1,6 +1,11 @@
-import org.json.JSONObject;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 import com.twilio.Twilio;
-import com.twilio.rest.video.v1.Recording;
+
+import org.json.JSONObject;
 
 
 public class Example {
@@ -16,13 +21,14 @@ public class Example {
         String recordingSid = "RTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
         TwilioRestClient restClient = Twilio.getRestClient();
         Request request = new Request(
-            HttpMethod.POST,
-            Domains.VIDEO.toString(),
-            "/v1/Recordings/" + recordingSid + "/Media/",
-            restClient.getRegion()
+                HttpMethod.GET,
+                Domains.VIDEO.toString(),
+                "/v1/Recordings/" + recordingSid + "/Media/",
+                restClient.getRegion()
         );
         Response response = restClient.request(request);
-        String mediaLocation = json.getJSONObject(response.getStream()).getString("location");
+        JSONObject json = new JSONObject(response.getStream());
+        String mediaLocation = json.getString("location");
 
         System.out.println(mediaLocation);
     }


### PR DESCRIPTION
Requesting a media resource should be by _GET_.

**TODO**
Update the examples for the languages:

- [x] C#
- [x] Java
- [x] PHP
- [x] Python
- [x] Ruby