### PR TITLE
Fix C# snippet to generate TaskRouter TaskQueue Capability Token

### DIFF
--- a/rest/taskrouter/jwts/taskqueue/example-1/example-1.5.x.cs
+++ b/rest/taskrouter/jwts/taskqueue/example-1/example-1.5.x.cs
@@ -35,7 +35,7 @@ class Example
             accountSid,
             authToken,
             workspaceSid,
-            null,
+            taskQueueSid,
             policies: policies,
             expiration: DateTime.UtcNow.AddSeconds(28800) // 60 * 60 * 8
             );
@@ -59,7 +59,7 @@ class PolicyUrlUtils
         _taskQueueSid = taskQueueSid;
     }
 
-    public string TaskQueue => $"{Workspace}/TaskQueue/{_taskQueueSid}";
+    public string TaskQueue => $"{Workspace}/TaskQueues/{_taskQueueSid}";
 
     string Workspace =>
         $"{taskRouterBaseUrl}/{taskRouterVersion}/Workspaces/{_workspaceSid}";


### PR DESCRIPTION
The current C# sample for "Creating a TaskRouter TaskQueue capability token" has 2 errors. 

1. The channel parameter of TaskRouterCapability constructor should be passed the TaskQueue Sid rather than null. A value of null causes an Exception  
`System.NullReferenceException occurred
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=<Cannot evaluate the exception source>
  StackTrace:
   at Twilio.Jwt.Taskrouter.TaskRouterCapability.get_Claims()
   at Twilio.Jwt.BaseJwt.ToJwt()`

2. There is a typo in the TaskQueue property of PolicyUrlUtils. The URL should have TaskQueues instead of TaskQueue

Fixing these 2 changes makes the sample work correctly. Current sample causes this [issue](https://stackoverflow.com/questions/46783017/error-in-twilio-net-sdk-making-taskroutercapability-for-taskqueue)
