### PR TITLE
BindingList function parameter

### DIFF
--- a/notifications/register/create-binding-server-apns/create-binding-server-apn.5.x.php
+++ b/notifications/register/create-binding-server-apns/create-binding-server-apn.5.x.php
@@ -19,11 +19,10 @@ $client = new Client($accountSid, $authToken);
 $binding = $client
     ->notify->services($serviceSid)
     ->bindings->create(
-        'endpoint_id', // Endpoint
         '00000001', // We recommend using a GUID or other anonymized identifier for Identity.
         'apn', // Binding type
         'apn_device_token', // Address
-        ['tag' => ['preferred device', 'new user']] // Options
+        ['endpoint'=>'endpoint_id', 'tag' => ['preferred device', 'new user']] // Options
     );
 
 echo $binding->sid;


### PR DESCRIPTION
twilio/sdk/Twilio/Rest/Notify/V1/Service/BindingList.php requires three input parameters. Endpoint is part of the options array. The example before had endpoint as the first input parameter. Sending 5 input attributes to the function returns an error.