### PR TITLE
Fixes `MessagingResponse`

### DIFF
--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.5.x.rb
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.5.x.rb
@@ -10,9 +10,9 @@ post '/sms' do
   # Build response based on given body param
   twiml = Twilio::TwiML::MessagingResponse.new do |resp|
     if body == 'hello'
-      resp.message 'Hi!'
+      resp.message body: 'Hi!'
     elsif body == 'bye'
-      resp.message 'Goodbye'
+      resp.message body: 'Goodbye'
     end
   end
 

--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.5.x.rb
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.5.x.rb
@@ -4,7 +4,7 @@ require 'sinatra'
 # Respond to incoming calls with a simple text message
 post '/sms' do
   twiml = Twilio::TwiML::MessagingResponse.new do |r|
-    r.message 'The Robots are coming! Head for the hills!'
+    r.message body: 'The Robots are coming! Head for the hills!'
   end
 
   content_type 'text/xml'


### PR DESCRIPTION
The latest `Message` object in TwiML requires a hash with a `body` rather than plain text.