### PR TITLE
Remove fetch() from POST call in ruby SDK

### DIFF
--- a/rest/change-call-state/example-1/example-1.5.x.rb
+++ b/rest/change-call-state/example-1/example-1.5.x.rb
@@ -8,7 +8,7 @@ auth_token = 'your_auth_token'
 # Initialize Twilio Client
 @client = Twilio::REST::Client.new(account_sid, auth_token)
 
-@call = @client.api.calls('CAe1644a7eed5088b159577c5802d8be38').fetch
+@call = @client.api.calls('CAe1644a7eed5088b159577c5802d8be38')
 
 @call.update(
   url: 'http://demo.twilio.com/docs/voice.xml',


### PR DESCRIPTION
Shouldn't be running a .fetch since it could potentially fail here due to the eventual consistency on the calls resource