### PR TITLE
TaskRouter JWT Workspace Channel Change

### DIFF
--- a/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
+++ b/rest/taskrouter/jwts/workspace/example-1/example-1.3.x.js
@@ -21,7 +21,7 @@ const capability = new TaskRouterCapability({
   accountSid: accountSid,
   authToken: authToken,
   workspaceSid: workspaceSid,
-  channelId: workerSid,
+  channelId: workspaceSid,
 });
 
 // Helper function to create Policy
@@ -45,7 +45,7 @@ function buildWorkspacePolicy(options) {
 // Event Bridge Policies
 const eventBridgePolicies = util.defaultEventBridgePolicies(
   accountSid,
-  workerSid
+  workspaceSid
 );
 
 const workspacePolicies = [


### PR DESCRIPTION
Right now in the docs we are referencing a WorkerSid when generating a Workspace JWT. Both the channelId and and policy should reference the WorkspaceSid instead