### PR TITLE
Add 5.x example

### DIFF
--- a/quickstart/python/sms/example-8/reply_to_message.5x.py
+++ b/quickstart/python/sms/example-8/reply_to_message.5x.py
@@ -1,0 +1,20 @@
+# /usr/bin/env python
+# Download the twilio-python library from twilio.com/docs/libraries/python
+from flask import Flask, request, redirect
+from twilio import twiml
+
+app = Flask(__name__)
+
+@app.route("/sms", methods=['GET', 'POST'])
+def sms_ahoy_reply():
+    """Respond to incoming messages with a friendly SMS."""
+    # Start our response
+    resp = twiml.Response()
+
+    # Add a message
+    resp.message("Ahoy! Thanks so much for your message.")
+
+    return str(resp)
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
While I'm increasingly on the side of us only showing the latest lib in Quickstarts, I want to keep this consistent with the other samples for now - and, this way, the code can be reused on other parts of the docs where we do want to give the 5.x option.