### PR TITLE
fix php proxy quickstart examples

### DIFF
--- a/proxy/quickstart/create-participant/create-participant.5.x.php
+++ b/proxy/quickstart/create-participant/create-participant.5.x.php
@@ -13,8 +13,8 @@ $session = $client
     ->sessions("KCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     ->participants->create(
         array(
-            "identifier" => "+15558675310",
-            "uniqueName" => "Alice"
+            "proxyIdentifier" => "+15558675310",
+            "friendlyName" => "Alice"
         )
     );
 

--- a/proxy/quickstart/create-service/create-service.5.x.php
+++ b/proxy/quickstart/create-service/create-service.5.x.php
@@ -15,4 +15,4 @@ $service = $client
       "callbackUrl" => "https://www.example.com/"
     ]);
 
-echo $service->friendlyName;
+echo $service->uniqueName;


### PR DESCRIPTION
The proxy quickstart examples in this PR were using the incorrect parameter names. And are now using the correct ones. 

resolves #604 
