### PR TITLE
fix redirect with URL that does not 404

### DIFF
--- a/twiml/message/your-response/your-response-1/output/your-response-1.twiml
+++ b/twiml/message/your-response/your-response-1/output/your-response-1.twiml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Message><Body>Hello World!</Body></Message>
-    <Redirect>https://demo.twilio.com/sms/welcome</Redirect>
+    <Redirect>https://demo.twilio.com/welcome/sms/</Redirect>
 </Response>

--- a/twiml/message/your-response/your-response-1/your-response-1.3.x.js
+++ b/twiml/message/your-response/your-response-1/your-response-1.3.x.js
@@ -3,6 +3,6 @@ const MessagingResponse = require('twilio').twiml.MessagingResponse;
 const response = new MessagingResponse();
 const message = response.message();
 message.body('Hello World!');
-response.redirect('https://demo.twilio.com/sms/welcome');
+response.redirect('https://demo.twilio.com/welcome/sms/');
 
 console.log(response.toString());

--- a/twiml/message/your-response/your-response-1/your-response-1.5.x.cs
+++ b/twiml/message/your-response/your-response-1/your-response-1.5.x.cs
@@ -11,7 +11,7 @@ class Example
         var message = new Message();
         message.Body("Hello World!");
         response.Append(message);
-        response.Redirect(url: new Uri("https://demo.twilio.com/sms/welcome"));
+        response.Redirect(url: new Uri("https://demo.twilio.com/welcome/sms/"));
 
         Console.WriteLine(response.ToString());;
     }

--- a/twiml/message/your-response/your-response-1/your-response-1.5.x.php
+++ b/twiml/message/your-response/your-response-1/your-response-1.5.x.php
@@ -5,6 +5,6 @@ use Twilio\Twiml;
 $response = new Twiml();
 $message = $response->message();
 $message->body('Hello World!');
-$response->redirect('https://demo.twilio.com/sms/welcome');
+$response->redirect('https://demo.twilio.com/welcome/sms/');
 
 echo $response;

--- a/twiml/message/your-response/your-response-1/your-response-1.5.x.rb
+++ b/twiml/message/your-response/your-response-1/your-response-1.5.x.rb
@@ -4,6 +4,6 @@ response = Twilio::TwiML::MessagingResponse.new
 response.message do |message|
   message.body('Hello World!')
 end
-response.redirect('https://demo.twilio.com/sms/welcome')
+response.redirect('https://demo.twilio.com/welcome/sms/')
 
 puts response

--- a/twiml/message/your-response/your-response-1/your-response-1.6.x.py
+++ b/twiml/message/your-response/your-response-1/your-response-1.6.x.py
@@ -4,6 +4,6 @@ response = MessagingResponse()
 message = Message()
 message.body('Hello World!')
 response.append(message)
-response.redirect('https://demo.twilio.com/sms/welcome')
+response.redirect('https://demo.twilio.com/welcome/sms/')
 
 print(response)

--- a/twiml/message/your-response/your-response-1/your-response-1.7.x.java
+++ b/twiml/message/your-response/your-response-1/your-response-1.7.x.java
@@ -10,7 +10,7 @@ public class Example {
         Body body = new Body("Hello World!");
         Message message = new Message.Builder().body(body).build();
         Redirect redirect = new Redirect.Builder()
-            .url("https://demo.twilio.com/sms/welcome").build();
+            .url("https://demo.twilio.com/welcome/sms/").build();
         MessagingResponse response = new MessagingResponse.Builder()
             .message(message).redirect(redirect).build();
 


### PR DESCRIPTION
The existing URL in this sample (https://demo.twilio.com/sms/welcome) 404s. It should be https://demo.twilio.com/welcome/sms/.