### PR TITLE
bugfix: pass RECORDING_ID instead of AUTH_TOKEN

### DIFF
--- a/rest/recording/get-recording-xml/get-recording-xml.7.x.java
+++ b/rest/recording/get-recording-xml/get-recording-xml.7.x.java
@@ -12,6 +12,6 @@ public class Example {
     public static void main(String[] args) {
         Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
 
-        Recording recording = Recording.fetcher(ACCOUNT_SID, AUTH_TOKEN).fetch();
+        Recording recording = Recording.fetcher(ACCOUNT_SID, RECORDING_ID).fetch();
     }
 }


### PR DESCRIPTION
Recording fetcher expects parameter 2 to  be recording_id, auth_token is passed instead.