### PR TITLE
Change res.end to res.sendStatus

### DIFF
--- a/rest/messages/sms-handle-callback/sms-handle-callback.3.x.js
+++ b/rest/messages/sms-handle-callback/sms-handle-callback.3.x.js
@@ -12,7 +12,7 @@ app.post('/MessageStatus', (req, res) => {
 
   console.log(`SID: ${messageSid}, Status: ${messageStatus}`);
 
-  res.end();
+  res.sendStatus(200);
 });
 
 http.createServer(app).listen(1337, () => {


### PR DESCRIPTION
Calling `res.end` without any other actions on the `res` will send a response without a content type. Twilio will complain about that with a warning in the debugger.

`res.sendStatus(200);` will set the content type to `text/plain` and the body to "OK". It also has more intention in it ("I want to send a successful response").