### PR TITLE
lookups code samples should demonstrate catching the 404 exception

### DIFF
--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.3.x.js
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.3.x.js
@@ -8,4 +8,11 @@ const client = require('twilio')(accountSid, authToken);
 client.lookups.v1
   .phoneNumbers('+15108675310')
   .fetch({type: 'carrier'})
-  .then(number => console.log(number));
+  .then(response => console.log(response.carrier))
+  .catch(error => {
+    if (error.status === 404) {
+      console.log('No carrier information');
+    } else {
+      console.log(error.message);
+    }
+  });

--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.cs
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Twilio;
 using Twilio.Rest.Lookups.V1;
 using Twilio.Types;
+using Twilio.Exceptions;
 
 public class Example
 {
@@ -15,12 +16,20 @@ public class Example
 
         TwilioClient.Init(accountSid, authToken);
 
-        // Look up a phone number in E.164 format
-        var phoneNumber = PhoneNumberResource.Fetch(
-            new PhoneNumber("+15108675310"),
-            type: new List<string> { "carrier" });
+        try {
+          // Look up a phone number in E.164 format
+          var phoneNumber = PhoneNumberResource.Fetch(
+              new PhoneNumber("+15108675310"),
+              type: new List<string> { "carrier" });
 
-        Console.WriteLine(phoneNumber.Carrier["name"]);
-        Console.WriteLine(phoneNumber.Carrier["type"]);
+          Console.WriteLine(phoneNumber.Carrier["name"]);
+          Console.WriteLine(phoneNumber.Carrier["type"]);
+        } catch (ApiException e) {
+          if (e.Status == 404) {
+            Console.WriteLine("No carrier information");
+          } else {
+            Console.WriteLine(e.ToString());
+          }
+        }
     }
 }

--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.php
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.php
@@ -3,6 +3,7 @@
 require_once '/path/to/vendor/autoload.php'; // Loads the library
 
 use Twilio\Rest\Client;
+use Twilio\Exceptions\RestException;
 
 // Your Account Sid and Auth Token from twilio.com/user/account
 $sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
@@ -10,11 +11,19 @@ $token = "your_auth_token";
 
 $client = new Client($sid, $token);
 
-$number = $client->lookups
-    ->phoneNumbers("+15108675310")
-    ->fetch(
-        array("type" => "carrier")
-    );
+try {
+  $number = $client->lookups
+      ->phoneNumbers("+15108675310")
+      ->fetch(
+          array("type" => "carrier")
+      );
 
-echo $number->carrier["type"] . "\r\n";
-echo $number->carrier["name"];
+  echo $number->carrier["type"] . "\r\n";
+  echo $number->carrier["name"];
+} catch (RestException $e) {
+    if ($e->getStatusCode() == "404") {
+        echo "No carrier information.\n";
+    } else {
+        throw $e;
+    }
+}

--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.rb
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.5.x.rb
@@ -6,7 +6,15 @@ account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 auth_token = 'your_auth_token'
 @client = Twilio::REST::Client.new(account_sid, auth_token)
 
-number = @client.lookups.v1.phone_numbers('+15108675310').fetch(type: 'carrier')
+begin
+  number = @client.lookups.v1.phone_numbers('+15108675310').fetch(type: 'carrier')
 
-puts number.carrier['type']
-puts number.carrier['name']
+  puts number.carrier['type']
+  puts number.carrier['name']
+rescue Twilio::REST::RestError => err
+  if err.status_code === 404
+    puts 'No carrier information'
+  else
+    puts err.message
+  end
+end

--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.6.x.py
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.6.x.py
@@ -6,7 +6,14 @@ account_sid = "ACCOUNT_SID"
 auth_token = "your_auth_token"
 client = Client(account_sid, auth_token)
 
-number = client.lookups.phone_numbers("+15108675310").fetch(type="carrier")
 
-print(number.carrier['type'])
-print(number.carrier['name'])
+try:
+    number = client.lookups.phone_numbers("+15108675310").fetch(type="carrier")
+
+    print(number.carrier['type'])
+    print(number.carrier['name'])
+except TwilioRestException as error:
+    if error.status == 404:
+        print('No carrier information')
+    else:
+        raise error

--- a/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.7.x.java
+++ b/lookups/lookup-get-basic-example-1/lookup-get-basic-example-1.7.x.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.twilio.Twilio;
 import com.twilio.rest.lookups.v1.PhoneNumber;
+import com.twilio.exception.ApiException;
 
 public class Example {
   // Find your Account Sid and Token at twilio.com/user/account
@@ -13,12 +14,20 @@ public class Example {
   public static void main(String[] args) {
     Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
 
-    PhoneNumber number = PhoneNumber
-        .fetcher(new com.twilio.type.PhoneNumber("+15108675310"))
-        .setType("carrier")
-        .fetch();
+    try {
+      PhoneNumber number = PhoneNumber
+          .fetcher(new com.twilio.type.PhoneNumber("+15108675310"))
+          .setType("carrier")
+          .fetch();
 
-    System.out.println(number.getCarrier().get("name"));
-    System.out.println(number.getCarrier().get("type"));
+      System.out.println(number.getCarrier().get("name"));
+      System.out.println(number.getCarrier().get("type"));
+    } catch (ApiException e) {
+      if (e.getStatusCode() == 404) {
+        System.out.println("No carrier information");
+      } else {
+        System.out.println(e.getMessage());
+      }
+    }
   }
 }


### PR DESCRIPTION
Lookups API does something that other APIs don't do – it returns an HTTP 404 when it can't find the carrier info for a number, which results in a runtime exception in helper libraries.

https://www.twilio.com/docs/api/lookups

Each code sample (for every language) on this page should demonstrate how to catch the runtime exception and check for the 404.