### PR TITLE
Add .urlencoded to bodyParser to fix deprecation warnings

### DIFF
--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.3.x.js
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.3.x.js
@@ -5,7 +5,7 @@ const bodyParser = require('body-parser');
 
 const app = express();
 
-app.use(bodyParser());
+app.use(bodyParser.urlencoded({ extended: false }));
 
 app.post('/', (req, res) => {
   const twiml = new MessagingResponse();


### PR DESCRIPTION
This change will fix the following body-parser deprecation warnings that appear in the console:

```
body-parser deprecated bodyParser: use individual json/urlencoded middlewares app.js:56:9
body-parser deprecated undefined extended: provide extended option node_modules/body-parser/index.js:105:29
```