### PR TITLE
Update TaskRouter JS version and Conference examples

### DIFF
--- a/quickstart/php/taskrouter/agent/agent.4.x.php
+++ b/quickstart/php/taskrouter/agent/agent.4.x.php
@@ -21,7 +21,7 @@ $workerToken = $workerCapability->generateToken();
 <head>
     <title>Customer Care - Voice Agent Screen</title>
     <link rel="stylesheet" href="//media.twiliocdn.com/taskrouter/quickstart/agent.css"/>
-    <script src="//media.twiliocdn.com/taskrouter/js/v1.8/taskrouter.min.js"></script>
+    <script src="//media.twiliocdn.com/taskrouter/js/v1.13/taskrouter.min.js"></script>
     <script src="agent.js"></script>
 </head>
 <body>

--- a/quickstart/php/taskrouter/agent/agent.5.x.php
+++ b/quickstart/php/taskrouter/agent/agent.5.x.php
@@ -22,7 +22,7 @@ $workerToken = $workerCapability->generateToken();
 <head>
     <title>Customer Care - Voice Agent Screen</title>
     <link rel="stylesheet" href="//media.twiliocdn.com/taskrouter/quickstart/agent.css"/>
-    <script src="//media.twiliocdn.com/taskrouter/js/v1.8/taskrouter.min.js"></script>
+    <script src="//media.twiliocdn.com/taskrouter/js/v1.13/taskrouter.min.js"></script>
     <script src="agent.js"></script>
 </head>
 <body>

--- a/rest/taskrouter/reservations/conference/example-1.2.x.js
+++ b/rest/taskrouter/reservations/conference/example-1.2.x.js
@@ -13,7 +13,9 @@ const client = new twilio.TaskRouterClient(accountSid, authToken, workspaceSid);
 // Update a Reservation with a Conference instruction
 client.workspace.tasks(taskSid).reservations(reservationSid).update({
   instruction: 'conference',
-  dequeueFrom: '+18001231234',
+  from: '+18001231234',
+  conferenceStatusCallback: 'https://www.example.com/ConferenceEvents',
+  conferenceStatusCallbackEvent: 'start end join leave mute hold'
 }, (err, reservation) => {
   console.log(reservation.reservation_status);
   console.log(reservation.worker_name);

--- a/rest/taskrouter/reservations/conference/example-1.3.x.js
+++ b/rest/taskrouter/reservations/conference/example-1.3.x.js
@@ -14,7 +14,9 @@ client.taskrouter.v1
   .reservations(reservationSid)
   .update({
     instruction: 'conference',
-    dequeueFrom: '+18001231234',
+    from: '+18001231234',
+    conferenceStatusCallback: 'https://www.example.com/ConferenceEvents',
+    conferenceStatusCallbackEvent: 'start end join leave mute hold'
   })
   .then(reservation => {
     console.log(reservation.reservationStatus);

--- a/rest/taskrouter/reservations/conference/example-1.4.x.cs
+++ b/rest/taskrouter/reservations/conference/example-1.4.x.cs
@@ -21,6 +21,9 @@ class Example
 
     client.UpdateReservation(WorkspaceSid, "Tasks", TaskSid, ReservationSid,
         instruction: "conference",
-        dequeueFrom: "+18001231234");
+        from: "+18001231234",
+        conferenceStatusCallback: "https://www.example.com/ConferenceEvents",
+        conferenceStatusCallbackEvent: new string[] { "start", "end", "join", "leave", "mute", "hold" }
+    );
   }
 }

--- a/rest/taskrouter/reservations/conference/example-1.4.x.php
+++ b/rest/taskrouter/reservations/conference/example-1.4.x.php
@@ -16,6 +16,8 @@ $reservation = $client->workspace->tasks->get($taskSid)->reservations->get($rese
 $reservation->update(
     array(
         'Instruction' => 'conference',
-        'DequeueFrom' => '+18001231234'
+        'From' => '+18001231234',
+        'ConferenceStatusCallback' => 'https://www.example.com/ConferenceEvents',
+        'ConferenceStatusCallbackEvent' => array("start", "end", "join", "leave", "mute", "hold")
     )
 );

--- a/rest/taskrouter/reservations/conference/example-1.4.x.rb
+++ b/rest/taskrouter/reservations/conference/example-1.4.x.rb
@@ -13,10 +13,14 @@ client = Twilio::REST::TaskRouterClient.new account_sid,
                                             workspace_sid
 
 # Update a Reservation with a Conference instruction
+status_callback = %w[start end join leave mute hold]
 reservation = client.workspace
                     .tasks.get(task_sid)
                     .reservations.get(reservation_sid)
 
-reservation.update(instruction: 'conference', dequeueFrom: '+18001231234')
+reservation.update(instruction: 'conference',
+                   from: '+18001231234',
+                   conference_status_callback: 'https://www.example.com/ConferenceEvents',
+                   conference_status_callback_event: status_callback)
 puts reservation.reservation_status
 puts reservation.worker_name

--- a/rest/taskrouter/reservations/conference/example-1.5.x.cs
+++ b/rest/taskrouter/reservations/conference/example-1.5.x.cs
@@ -1,6 +1,7 @@
 // Download the twilio-csharp library from
 // https://www.twilio.com/docs/libraries/csharp#installation
 using System;
+using System.Collections.Generic;
 using Twilio;
 using Twilio.Rest.Taskrouter.V1.Workspace.Task;
 
@@ -25,7 +26,19 @@ class Example
         Console.WriteLine(reservation.WorkerName);
 
         ReservationResource.Update(
-            workspaceSid, taskSid, reservationSid, instruction: "conference",
-            dequeueFrom: "+18001231234");
+            workspaceSid, taskSid, reservationSid,
+            instruction: "conference",
+            from: "+18001231234",
+            conferenceStatusCallback: "https://www.example.com/ConferenceEvents",
+            conferenceStatusCallbackEvent: new List<ReservationResource.ConferenceEventEnum>
+            {
+                ReservationResource.ConferenceEventEnum.Start,
+                ReservationResource.ConferenceEventEnum.End,
+                ReservationResource.ConferenceEventEnum.Join,
+                ReservationResource.ConferenceEventEnum.Leave,
+                ReservationResource.ConferenceEventEnum.Mute,
+                ReservationResource.ConferenceEventEnum.Hold
+            }
+        );
     }
 }

--- a/rest/taskrouter/reservations/conference/example-1.5.x.php
+++ b/rest/taskrouter/reservations/conference/example-1.5.x.php
@@ -23,6 +23,8 @@ $reservation = $client->taskrouter
 $reservation->update(
     array(
         'instruction' => 'conference',
-        'dequeueFrom' => '+18001231234'
+        'from' => '+18001231234',
+        'conferenceStatusCallback' => 'https://www.example.com/ConferenceEvents',
+        'conferenceStatusCallbackEvent' => array("start", "end", "join", "leave", "mute", "hold")
     )
 );

--- a/rest/taskrouter/reservations/conference/example-1.5.x.py
+++ b/rest/taskrouter/reservations/conference/example-1.5.x.py
@@ -12,7 +12,11 @@ client = TwilioTaskRouterClient(account_sid, auth_token)
 
 # Update a Reservation with a Conference instruction
 reservation = client.reservations(workspace_sid, task_sid).update(
-    reservation_sid, instruction='conference', dequeue_from='+18001231234'
+    reservation_sid,
+    instruction='conference',
+    from_='+18001231234',
+    conference_status_callback='https://www.example.com/ConferenceEvents',
+    conference_status_callback_event=["start", "end", "join", "leave", "mute", "hold"]
 )
 print(reservation.reservation_status)
 print(reservation.worker_name)

--- a/rest/taskrouter/reservations/conference/example-1.5.x.rb
+++ b/rest/taskrouter/reservations/conference/example-1.5.x.rb
@@ -8,14 +8,17 @@ workspace_sid   = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 task_sid        = 'WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 reservation_sid = 'WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
-client = Twilio::REST::Client.new(account_sid, auth_token)
+@client = Twilio::REST::Client.new(account_sid, auth_token)
 
-reservation = client.taskrouter.v1.workspaces(workspace_sid)
+reservation = @client.taskrouter.v1.workspaces(workspace_sid)
                     .tasks(task_sid).reservations(reservation_sid)
 
 # Update a Reservation with a Conference instruction
+status_callback = %w[start end join leave mute hold]
 reservation = reservation.update(instruction:  'conference',
-                                 dequeue_from: '+18001231234')
+                                 from: '+18001231234',
+                                 conference_status_callback: 'https://www.example.com/ConferenceEvents',
+                                 conference_status_callback_event: status_callback)
 
 puts reservation.reservation_status
 

--- a/rest/taskrouter/reservations/conference/example-1.6.x.java
+++ b/rest/taskrouter/reservations/conference/example-1.6.x.java
@@ -1,6 +1,8 @@
 // Install the Java helper library from twilio.com/docs/java/install
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
 
 import com.twilio.sdk.TwilioRestException;
 import com.twilio.sdk.TwilioTaskRouterClient;
@@ -23,9 +25,16 @@ public class Example {
     Reservation reservation = client.getReservation(WORKSPACE_SID, TASK_SID, RESERVATION_SID);
 
     // Update a Reservation with a Conference instruction
-    Map<String, String> params = new HashMap<String, String>();
-    params.put("Instruction", "conference");
-    params.put("DequeueFrom", "+18001231234");
+    List<NameValuePair> params = new ArrayList<NameValuePair>();
+    params.add(new BasicNameValuePair("Instruction", "conference"));
+    params.add(new BasicNameValuePair("From", "+18001231234"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallback", "https://www.example.com/ConferenceEvents"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "start"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "end"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "join"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "leave"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "mute"));
+    params.add(new BasicNameValuePair("ConferenceStatusCallbackEvent", "hold"));
     reservation.update(params);
   }
 }

--- a/rest/taskrouter/reservations/conference/example-1.6.x.py
+++ b/rest/taskrouter/reservations/conference/example-1.6.x.py
@@ -13,7 +13,12 @@ client = Client(account_sid, auth_token)
 #  Update a Reservation with a Conference instruction
 reservation = client.taskrouter.workspaces(workspace_sid) \
     .tasks(task_sid).reservations(reservation_sid) \
-    .update(instruction='conference', dequeue_from='+18001231234')
+    .update(
+        instruction='conference',
+        from_='+18001231234',
+        conference_status_callback='https://www.example.com/ConferenceEvents',
+        conference_status_callback_event=["start", "end", "join", "leave", "mute", "hold"]
+    )
 
 print(reservation.reservation_status)
 print(reservation.worker_name)

--- a/rest/taskrouter/reservations/conference/example-1.7.x.java
+++ b/rest/taskrouter/reservations/conference/example-1.7.x.java
@@ -1,6 +1,8 @@
 // Install the Java helper library from twilio.com/docs/java/install
 import com.twilio.Twilio;
 import com.twilio.rest.taskrouter.v1.workspace.task.Reservation;
+import java.util.Arrays;
+import java.net.URI;
 
 public class Example {
   // Find your Account Sid and Token at twilio.com/user/account
@@ -16,7 +18,16 @@ public class Example {
      // Update a Reservation with a Conference instruction
     Reservation reservation = Reservation.updater(WORKSPACE_SID, TASK_SID, RESERVATION_SID)
         .setInstruction("conference")
-        .setDequeueFrom("+18001231234")
+        .setFrom("+18001231234")
+        .setConferenceStatusCallback(URI.create("https://www.example.com/ConferenceEvents"))
+        .setConferenceStatusCallbackEvent(Arrays.asList(
+          Reservation.ConferenceEvent.START,
+          Reservation.ConferenceEvent.END,
+          Reservation.ConferenceEvent.JOIN,
+          Reservation.ConferenceEvent.LEAVE,
+          Reservation.ConferenceEvent.MUTE,
+          Reservation.ConferenceEvent.HOLD)
+        )
         .update();
 
     System.out.println(reservation.getDateUpdated());

--- a/rest/taskrouter/reservations/conference/example-1.json.curl
+++ b/rest/taskrouter/reservations/conference/example-1.json.curl
@@ -1,4 +1,11 @@
 curl -XPOST https://taskrouter.twilio.com/v1/Workspaces/WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Tasks/WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Reservations/WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
     -d "Instruction=conference" \
-    -d "DequeueFrom=+18001231234" \
+    -d "From=+18001231234" \
+    -d "ConferenceStatusCallback=https://www.example.com/ConferenceEvents" \
+    -d "ConferenceStatusCallbackEvent=start" \
+    -d "ConferenceStatusCallbackEvent=end" \
+    -d "ConferenceStatusCallbackEvent=join" \
+    -d "ConferenceStatusCallbackEvent=leave" \
+    -d "ConferenceStatusCallbackEvent=mute" \
+    -d "ConferenceStatusCallbackEvent=hold" \
     -u '{account_sid}:{auth_token}'


### PR DESCRIPTION
The goal of the conference updates was to stop using 'dequeueFrom' as the example parameter (and get rid of the trailing comma). I added ConferenceStatusCallback because this is a very common help request we get from customers, and it has not been clear how to successfully add them. The examples for each language are largely derived from https://www.twilio.com/docs/voice/make-calls#make-a-call-and-monitor-progress-events and https://www.twilio.com/docs/voice/api/conference-participant#participants-list-resource, with a few references from the helper libraries to figure out the expected types for TaskRouter-specific methods.

These snippets have not been tested against the libraries.