### PR TITLE
Corrects how you access AccessToken with Twilio Node v3.

### DIFF
--- a/ip-messaging/users/token-generation-server/token-generation-server.3.x.js
+++ b/ip-messaging/users/token-generation-server/token-generation-server.3.x.js
@@ -1,7 +1,7 @@
 require('dotenv').load();
 const http = require('http');
 const path = require('path');
-const AccessToken = require('twilio').AccessToken;
+const AccessToken = require('twilio').jwt.AccessToken;
 const ChatGrant = AccessToken.ChatGrant;
 const express = require('express');
 // Create Express webapp

--- a/video/users/token-generation-server-rooms/token-generation-server.3.x.js
+++ b/video/users/token-generation-server-rooms/token-generation-server.3.x.js
@@ -3,7 +3,7 @@ require('dotenv').load();
 const http = require('http');
 const path = require('path');
 
-const AccessToken = require('twilio').AccessToken;
+const AccessToken = require('twilio').jwt.AccessToken;
 const VideoGrant = AccessToken.VideoGrant;
 const express = require('express');
 const randomUsername = require('./randos');

--- a/video/users/token-generation-server/token-generation-server.3.x.js
+++ b/video/users/token-generation-server/token-generation-server.3.x.js
@@ -3,8 +3,8 @@ require('dotenv').load();
 const http = require('http');
 const path = require('path');
 
-const AccessToken = require('twilio').AccessToken;
-const ConversationsGrant = AccessToken.ConversationsGrant;
+const AccessToken = require('twilio').jwt.AccessToken;
+const VideoGrant = AccessToken.VideoGrant;
 const express = require('express');
 const randomUsername = require('./randos');
 


### PR DESCRIPTION
The important change is that we were missing the `jwt` in:

```
const AccessToken = require('twilio').jwt.AccessToken;
```

Secondarily, the `ConversationGrant` was still being used in the video example.