### PR TITLE
Change RawUrl to AbsoluteUri

### DIFF
--- a/guides/request-validation-csharp/example-1/example-1.cs
+++ b/guides/request-validation-csharp/example-1/example-1.cs
@@ -31,7 +31,7 @@ namespace ValidateRequestExample.Filters
 
         private bool IsValidRequest(HttpRequestBase request) {
             var signature = request.Headers["X-Twilio-Signature"];
-            var requestUrl = request.RawUrl;
+            var requestUrl = request.Url.AbsoluteUri;
             return _requestValidator.Validate(requestUrl, request.Form, signature);
         }
     }


### PR DESCRIPTION
RawUrl only returns content after the url following the domain information. The request calculation should be based on the full Url which AbsoluteUri returns.