### PR TITLE
Update snippets to use correct type for Call Status Events

### DIFF
--- a/rest/making-calls/example-4/example-4.5.x.cs
+++ b/rest/making-calls/example-4/example-4.5.x.cs
@@ -17,11 +17,12 @@ class Example
 
         var to = new PhoneNumber("+14155551212");
         var from = new PhoneNumber("+18668675310");
-        var statusCallbackEvents = new List<string>() {
-            "initiated",
-            "ringing",
-            "answered",
-            "completed" };
+        var statusCallbackEvents = new List<EventEnum>()
+            EventEnum.Initiated,
+            EventEnum.Ringing,
+            EventEnum.Answered,
+            EventEnum.Completed
+        };
 
         var call = CallResource.Create(
             to,

--- a/rest/making-calls/example-4/example-4.5.x.rb
+++ b/rest/making-calls/example-4/example-4.5.x.rb
@@ -15,7 +15,7 @@ auth_token = 'your_auth_token'
   method: 'GET',
   status_callback: 'https://www.myapp.com/events',
   status_callback_method: 'POST',
-  status_callback_event: %w[initiated ringing answered completed]
+  status_callback_event: 'initiated ringing answered completed'
 )
 
 puts @call.start_time

--- a/rest/making-calls/example-4/example-4.7.x.java
+++ b/rest/making-calls/example-4/example-4.7.x.java
@@ -1,30 +1,42 @@
 // Install the Java helper library from twilio.com/docs/java/install
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.List;
+import java.util.ArrayList;
 
 import com.twilio.Twilio;
 import com.twilio.http.HttpMethod;
 import com.twilio.rest.api.v2010.account.Call;
 import com.twilio.type.PhoneNumber;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 public class Example {
-  // Find your Account Sid and Token at twilio.com/user/account
-  public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-  public static final String AUTH_TOKEN = "your_auth_token";
+    // Find your Account Sid and Token at twilio.com/user/account
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
 
-  public static void main(String[] args) throws URISyntaxException {
-    Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+    public static void main(String[] args) throws URISyntaxException {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
 
-    List<String> callbackEvents = Arrays.asList("initiated", "ringing", "answered", "completed");
+        ArrayList<String> callbackEvents = newArrayList(
+            "initiated",
+            "ringing",
+            "answered",
+            "completed"
+        );
 
-    Call call = Call
-        .creator(new PhoneNumber("+14155551212"), new PhoneNumber("+18668675310"),
-            new URI("http://demo.twilio.com/docs/voice.xml"))
-        .setMethod(HttpMethod.GET).setStatusCallback("https://www.myapp.com/events")
-        .setStatusCallbackMethod(HttpMethod.POST).setStatusCallbackEvent(callbackEvents).create();
+        Call call = Call
+            .creator(
+                new PhoneNumber("+14155551212"),
+                new PhoneNumber("+18668675310"),
+                new URI("http://demo.twilio.com/docs/voice.xml")
+            )
+            .setMethod(HttpMethod.GET)
+            .setStatusCallback("https://www.myapp.com/events")
+            .setStatusCallbackMethod(HttpMethod.POST)
+            .setStatusCallbackEvent(callbackEvents)
+            .create();
 
-    System.out.println(call.getSid());
-  }
+        System.out.println(call.getSid());
+    }
 }

--- a/rest/making-calls/example-4/example-4.json.curl
+++ b/rest/making-calls/example-4/example-4.json.curl
@@ -5,8 +5,5 @@ curl -XPOST https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXX
     --data-urlencode "Method=GET" \
     --data-urlencode "StatusCallback=https://www.myapp.com/events" \
     --data-urlencode "StatusCallbackMethod=POST" \
-    --data-urlencode "StatusCallbackEvent=initiated" \
-    --data-urlencode "StatusCallbackEvent=ringing" \
-    --data-urlencode "StatusCallbackEvent=answered" \
-    --data-urlencode "StatusCallbackEvent=completed" \
+    --data-urlencode "StatusCallbackEvent=initiated ringing answered completed" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/rest/making-calls/example-4/example-4.xml.curl
+++ b/rest/making-calls/example-4/example-4.xml.curl
@@ -5,8 +5,5 @@ curl -XPOST https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXX
     --data-urlencode "Method=GET" \
     --data-urlencode "StatusCallback=https://www.myapp.com/events" \
     --data-urlencode "StatusCallbackMethod=POST" \
-    --data-urlencode "StatusCallbackEvent=initiated" \
-    --data-urlencode "StatusCallbackEvent=ringing" \
-    --data-urlencode "StatusCallbackEvent=answered" \
-    --data-urlencode "StatusCallbackEvent=completed" \
+    --data-urlencode "StatusCallbackEvent=initiated ringing answered completed" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/rest/taskrouter/reservations/conference/conference.3.x.js
+++ b/rest/taskrouter/reservations/conference/conference.3.x.js
@@ -16,8 +16,14 @@ client.taskrouter.v1
     instruction: 'conference',
     from: '+18001231234',
     conferenceStatusCallback: 'https://www.example.com/ConferenceEvents',
-    conferenceStatusCallbackEvent: ["start", "end", "join", "leave", "mute", "hold"]
-  })
+    conferenceStatusCallbackEvent: [
+      'start',
+      'end',
+      'join',
+      'leave',
+      'mute',
+      'hold'
+    ]})
   .then(reservation => {
     console.log(reservation.reservationStatus);
     console.log(reservation.workerName);

--- a/rest/taskrouter/reservations/conference/conference.json.curl
+++ b/rest/taskrouter/reservations/conference/conference.json.curl
@@ -2,10 +2,5 @@ curl -XPOST https://taskrouter.twilio.com/v1/Workspaces/WSXXXXXXXXXXXXXXXXXXXXXX
     -d "Instruction=conference" \
     -d "From=+18001231234" \
     -d "ConferenceStatusCallback=https://www.example.com/ConferenceEvents" \
-    -d "ConferenceStatusCallbackEvent=start" \
-    -d "ConferenceStatusCallbackEvent=end" \
-    -d "ConferenceStatusCallbackEvent=join" \
-    -d "ConferenceStatusCallbackEvent=leave" \
-    -d "ConferenceStatusCallbackEvent=mute" \
-    -d "ConferenceStatusCallbackEvent=hold" \
+    -d "ConferenceStatusCallbackEvent=start end join leave mute hold" \
     -u '{account_sid}:{auth_token}'

--- a/rest/voice/outbound-calls/example-4/example-4.5.x.cs
+++ b/rest/voice/outbound-calls/example-4/example-4.5.x.cs
@@ -17,8 +17,12 @@ class Example
 
         var to = new PhoneNumber("+14155551212");
         var from = new PhoneNumber("+18668675310");
-        var statusCallbackEvents = new List<string>() {
-            "initiated", "ringing", "answered", "completed" };
+        var statusCallbackEvents = new List<EventEnum>() {
+            EventEnum.Initiated,
+            EventEnum.Ringing,
+            EventEnum.Answered,
+            EventEnum.Completed
+        };
         var call = CallResource.Create(
             to,
             from,

--- a/rest/voice/outbound-calls/example-4/example-4.5.x.rb
+++ b/rest/voice/outbound-calls/example-4/example-4.5.x.rb
@@ -13,7 +13,7 @@ call = @client.calls.create(
   method: 'GET',
   status_callback: 'https://www.myapp.com/events',
   status_callback_method: 'POST',
-  status_callback_event: %w[initiated ringing answered completed]
+  status_callback_event: 'initiated ringing answered completed'
 )
 
 puts call.start_time

--- a/rest/voice/outbound-calls/example-4/example-4.json.curl
+++ b/rest/voice/outbound-calls/example-4/example-4.json.curl
@@ -5,8 +5,5 @@ curl -XPOST https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXX
     -d "Method=GET" \
     -d "StatusCallback=https://www.myapp.com/events" \
     -d "StatusCallbackMethod=POST" \
-    -d "StatusCallbackEvent=initiated" \
-    -d "StatusCallbackEvent=ringing" \
-    -d "StatusCallbackEvent=answered" \
-    -d "StatusCallbackEvent=completed" \
+    -d "StatusCallbackEvent=initiated ringing answered completed" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/rest/voice/outbound-calls/example-4/example-4.xml.curl
+++ b/rest/voice/outbound-calls/example-4/example-4.xml.curl
@@ -5,8 +5,5 @@ curl -XPOST https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXX
     -d "Method=GET" \
     -d "StatusCallback=https://www.myapp.com/events" \
     -d "StatusCallbackMethod=POST" \
-    -d "StatusCallbackEvent=initiated" \
-    -d "StatusCallbackEvent=ringing" \
-    -d "StatusCallbackEvent=answered" \
-    -d "StatusCallbackEvent=completed" \
+    -d "StatusCallbackEvent=initiated ringing answered completed" \
     -u 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token'

--- a/twiml/voice/client/client-3/client-3.3.x.js
+++ b/twiml/voice/client/client-3/client-3.3.x.js
@@ -4,7 +4,7 @@ const response = new VoiceResponse();
 const dial = response.dial();
 dial.client(
   {
-    statusCallbackEvent: 'initiated ringing answered completed',
+    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
     statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },

--- a/twiml/voice/client/client-3/client-3.5.x.cs
+++ b/twiml/voice/client/client-3/client-3.5.x.cs
@@ -13,14 +13,12 @@ class Example
         var dial = new Dial();
 
         dial.Client("joey",
-            statusCallbackEvent: new List<EventEnum>(
-                new EventEnum[] {
+            statusCallbackEvent: new List<EventEnum>() {
                     EventEnum.Initiated,
                     EventEnum.Ringing,
                     EventEnum.Answered,
                     EventEnum.Completed
-                }
-            ),
+                },
             statusCallback: new Uri("https://myapp.com/calls/events"),
             statusCallbackMethod: HttpMethod.Post);
 

--- a/twiml/voice/client/client-3/client-3.5.x.php
+++ b/twiml/voice/client/client-3/client-3.5.x.php
@@ -1,12 +1,14 @@
 <?php
-require_once './vendor/autoload.php';
-use Twilio\TwiML;
+require './vendor/autoload.php';
+use Twilio\Twiml;
 
 $response = new TwiML();
 $dial = $response->dial();
 $dial->client('joey',
-    ['statusCallbackEvent' => 'initiated ringing answered completed',
-    'statusCallback' => 'https://myapp.com/calls/events',
-    'statusCallbackMethod' => 'POST']);
+    [
+      'statusCallbackEvent' => array('initiated', 'ringing', 'answered', 'completed'),
+      'statusCallback' => 'https://myapp.com/calls/events',
+      'statusCallbackMethod' => 'POST'
+    ]);
 
 echo $response;

--- a/twiml/voice/client/client-3/client-3.6.x.py
+++ b/twiml/voice/client/client-3/client-3.6.x.py
@@ -4,7 +4,7 @@ response = VoiceResponse()
 dial = Dial()
 dial.client(
     'joey',
-    status_callback_event='initiated ringing answered completed',
+    status_callback_event=['initiated', 'ringing', 'answered', 'completed'],
     status_callback='https://myapp.com/calls/events',
     status_callback_method='POST'
 )

--- a/twiml/voice/client/client-3/client-3.7.x.java
+++ b/twiml/voice/client/client-3/client-3.7.x.java
@@ -4,15 +4,24 @@ import com.twilio.twiml.voice.Dial;
 import com.twilio.twiml.VoiceResponse;
 import com.twilio.twiml.TwiMLException;
 import java.util.Arrays;
+import java.util.List;
+
 import com.twilio.http.HttpMethod;
 
 public class Example {
     public static void main(String[] args) {
+        List<Event> events = Arrays.asList(
+            Event.INITIATED,
+            Event.RINGING,
+            Event.ANSWERED,
+            Event.COMPLETED
+        );
+
         Client client = new Client.Builder("joey")
             .statusCallback("https://myapp.com/calls/events")
-            .statusCallbackMethod(HttpMethod.POST).statusCallbackEvents(Arrays
-            .asList(Event.INITIATED, Event.RINGING, Event.ANSWERED, Event
-            .COMPLETED)).build();
+            .statusCallbackMethod(HttpMethod.POST)
+            .statusCallbackEvents(events).build();
+
         Dial dial = new Dial.Builder().client(client).build();
         VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
 

--- a/twiml/voice/client/client-3/composer.json
+++ b/twiml/voice/client/client-3/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "twilio/sdk": "^5.21"
+    }
+}

--- a/twiml/voice/client/client-3/composer.lock
+++ b/twiml/voice/client/client-3/composer.lock
@@ -1,0 +1,64 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c60185d6d74df955ffe175178ef2880a",
+    "packages": [
+        {
+            "name": "twilio/sdk",
+            "version": "5.21.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twilio/twilio-php.git",
+                "reference": "b87bde9642a34da9f2ce0417e1aaf572bfd2aec0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/b87bde9642a34da9f2ce0417e1aaf572bfd2aec0",
+                "reference": "b87bde9642a34da9f2ce0417e1aaf572bfd2aec0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "apigen/apigen": "^4.1",
+                "phpunit/phpunit": "4.5.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Twilio\\": "Twilio/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Twilio API Team",
+                    "email": "api@twilio.com"
+                }
+            ],
+            "description": "A PHP wrapper for Twilio's API",
+            "homepage": "http://github.com/twilio/twilio-php",
+            "keywords": [
+                "api",
+                "sms",
+                "twilio"
+            ],
+            "time": "2018-08-23T18:50:56+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/twiml/voice/conference/conference-4/conference-4.3.x.js
+++ b/twiml/voice/conference/conference-4/conference-4.3.x.js
@@ -5,7 +5,7 @@ const dial = response.dial();
 dial.conference(
   {
     statusCallback: 'https://myapp.com/events',
-    statusCallbackEvent: 'start end join leave mute hold',
+    statusCallbackEvent: ['start', 'end', 'join', 'leave', 'mute', 'hold']
   },
   'EventedConf'
 );

--- a/twiml/voice/conference/conference-4/conference-4.5.x.php
+++ b/twiml/voice/conference/conference-4/conference-4.5.x.php
@@ -4,8 +4,9 @@ use Twilio\TwiML;
 
 $response = new TwiML();
 $dial = $response->dial();
-$dial->conference('EventedConf',
-    ['statusCallback' => 'https://myapp.com/events',
-    'statusCallbackEvent' => 'start end join leave mute hold']);
+$dial->conference('EventedConf', [
+  'statusCallback' => 'https://myapp.com/events',
+  'statusCallbackEvent' => array('start', 'end', 'join', 'leave', 'mute', 'hold')
+]);
 
 echo $response;

--- a/twiml/voice/conference/conference-4/conference-4.6.x.py
+++ b/twiml/voice/conference/conference-4/conference-4.6.x.py
@@ -5,7 +5,7 @@ dial = Dial()
 dial.conference(
     'EventedConf',
     status_callback='https://myapp.com/events',
-    status_callback_event='start end join leave mute hold'
+    status_callback_event=['start', 'end', 'join', 'leave', 'mute', 'hold']
 )
 response.append(dial)
 

--- a/twiml/voice/conference/conference-4/conference-4.7.x.java
+++ b/twiml/voice/conference/conference-4/conference-4.7.x.java
@@ -3,15 +3,26 @@ import com.twilio.twiml.voice.Conference;
 import com.twilio.twiml.voice.Dial;
 import com.twilio.twiml.VoiceResponse;
 import java.util.Arrays;
+import java.util.List;
+
 import static com.twilio.twiml.voice.Conference.Event;
 
 public class Example {
     public static void main(String[] args) {
+        List<Event> events = Arrays.asList(
+            Event.START,
+            Event.END,
+            Event.JOIN,
+            Event.LEAVE,
+            Event.MUTE,
+            Event.HOLD
+        );
+
         Conference conference = new Conference.Builder("EventedConf")
             .statusCallback("https://myapp.com/events")
-            .statusCallbackEvents(Arrays.asList(Event.START,
-            Event.END, Event.JOIN, Event.LEAVE,
-            Event.MUTE, Event.HOLD)).build();
+            .statusCallbackEvents(events)
+            .build();
+
         Dial dial = new Dial.Builder().conference(conference).build();
         VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
 

--- a/twiml/voice/number/number-3/number-3.3.x.js
+++ b/twiml/voice/number/number-3/number-3.3.x.js
@@ -4,7 +4,7 @@ const response = new VoiceResponse();
 const dial = response.dial();
 dial.number(
   {
-    statusCallbackEvent: 'initiated ringing answered completed',
+    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed']
     statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },

--- a/twiml/voice/number/number-3/number-3.5.x.php
+++ b/twiml/voice/number/number-3/number-3.5.x.php
@@ -4,9 +4,10 @@ use Twilio\TwiML;
 
 $response = new TwiML();
 $dial = $response->dial();
-$dial->number('+14158675310',
-    ['statusCallbackEvent' => 'initiated ringing answered completed',
-    'statusCallback' => 'https://myapp.com/calls/events',
-    'statusCallbackMethod' => 'POST']);
+$dial->number('+14158675310', [
+  'statusCallbackEvent' => array('initiated', 'ringing', 'answered', 'completed'),
+  'statusCallback' => 'https://myapp.com/calls/events',
+  'statusCallbackMethod' => 'POST'
+]);
 
 echo $response;

--- a/twiml/voice/number/number-3/number-3.6.x.py
+++ b/twiml/voice/number/number-3/number-3.6.x.py
@@ -4,7 +4,7 @@ response = VoiceResponse()
 dial = Dial()
 dial.number(
     '+14158675310',
-    status_callback_event='initiated ringing answered completed',
+    status_callback_event=['initiated', 'ringing', 'answered', 'completed']
     status_callback='https://myapp.com/calls/events',
     status_callback_method='POST'
 )

--- a/twiml/voice/number/number-3/number-3.7.x.java
+++ b/twiml/voice/number/number-3/number-3.7.x.java
@@ -5,14 +5,23 @@ import com.twilio.twiml.voice.Number;
 import com.twilio.twiml.voice.Number.Event;
 import com.twilio.twiml.VoiceResponse;
 import java.util.Arrays;
+import java.util.List;
 
 public class Example {
     public static void main(String[] args) {
+        List<Event> events = Arrays.asList(
+            Event.INITIATED,
+            Event.RINGING,
+            Event.ANSWERED,
+            Event.COMPLETED
+        );
+
         Number number = new Number.Builder("+14158675310")
             .statusCallback("https://myapp.com/calls/events")
-            .statusCallbackMethod(HttpMethod.POST).statusCallbackEvents(Arrays
-            .asList(Event.INITIATED, Event.RINGING, Event.ANSWERED, Event
-            .COMPLETED)).build();
+            .statusCallbackMethod(HttpMethod.POST)
+            .statusCallbackEvents(events)
+            .build();
+
         Dial dial = new Dial.Builder().number(number).build();
         VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
 

--- a/twiml/voice/number/number-4/number-4.3.x.js
+++ b/twiml/voice/number/number-4/number-4.3.x.js
@@ -2,18 +2,20 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 
 const response = new VoiceResponse();
 const dial = response.dial();
+
 dial.number(
   {
-    statusCallbackEvent: 'initiated ringing answered completed',
+    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
     statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },
   '+14155555555'
 );
+
 dial.number(
   {
-    statusCallbackEvent: 'initiated ringing answered completed',
-    statusCallback: 'https://example.com/events',
+    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
+    statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },
   '+14153333333'

--- a/twiml/voice/number/number-4/number-4.5.x.php
+++ b/twiml/voice/number/number-4/number-4.5.x.php
@@ -5,11 +5,11 @@ use Twilio\TwiML;
 $response = new TwiML();
 $dial = $response->dial();
 $dial->number('+14155555555',
-    ['statusCallbackEvent' => 'initiated ringing answered completed',
+    ['statusCallbackEvent' => array('initiated', 'ringing', 'answered', 'completed'),
     'statusCallback' => 'https://myapp.com/calls/events',
     'statusCallbackMethod' => 'POST']);
 $dial->number('+14153333333',
-    ['statusCallbackEvent' => 'initiated ringing answered completed',
+    ['statusCallbackEvent' => array('initiated', 'ringing', 'answered', 'completed'),
     'statusCallback' => 'https://example.com/events',
     'statusCallbackMethod' => 'POST']);
 

--- a/twiml/voice/number/number-4/number-4.6.x.py
+++ b/twiml/voice/number/number-4/number-4.6.x.py
@@ -4,13 +4,15 @@ response = VoiceResponse()
 dial = Dial()
 dial.number(
     '+14155555555',
-    status_callback_event='initiated ringing answered completed',
+    status_callback_event=['initiated', 'ringing', 'answered', 'completed']
+,
     status_callback='https://myapp.com/calls/events',
     status_callback_method='POST'
 )
 dial.number(
     '+14153333333',
-    status_callback_event='initiated ringing answered completed',
+    status_callback_event=['initiated', 'ringing', 'answered', 'completed']
+,
     status_callback='https://example.com/events',
     status_callback_method='POST'
 )

--- a/twiml/voice/number/number-4/number-4.7.x.java
+++ b/twiml/voice/number/number-4/number-4.7.x.java
@@ -5,19 +5,29 @@ import com.twilio.twiml.voice.Number;
 import com.twilio.twiml.voice.Number.Event;
 import com.twilio.twiml.VoiceResponse;
 import java.util.Arrays;
+import java.util.List;
 
 public class Example {
     public static void main(String[] args) {
+        List<Event> events = Arrays.asList(
+            Event.INITIATED,
+            Event.RINGING,
+            Event.ANSWERED,
+            Event.COMPLETED
+        );
+
         Number number = new Number.Builder("+14155555555")
             .statusCallback("https://myapp.com/calls/events")
-            .statusCallbackMethod(HttpMethod.POST).statusCallbackEvents(Arrays
-            .asList(Event.INITIATED, Event.RINGING, Event.ANSWERED, Event
-            .COMPLETED)).build();
+            .statusCallbackMethod(HttpMethod.POST)
+            .statusCallbackEvents(events)
+            .build();
+
         Number number2 = new Number.Builder("+14153333333")
             .statusCallback("https://example.com/events")
-            .statusCallbackMethod(HttpMethod.POST).statusCallbackEvents(Arrays
-            .asList(Event.INITIATED, Event.RINGING, Event.ANSWERED, Event
-            .COMPLETED)).build();
+            .statusCallbackMethod(HttpMethod.POST)
+            .statusCallbackEvents(events)
+            .build();
+
         Dial dial = new Dial.Builder().number(number).number(number2).build();
         VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
 

--- a/twiml/voice/sip/sip-10/sip-10.3.x.js
+++ b/twiml/voice/sip/sip-10/sip-10.3.x.js
@@ -4,7 +4,7 @@ const response = new VoiceResponse();
 const dial = response.dial();
 dial.sip(
   {
-    statusCallbackEvent: 'initiated ringing answered completed',
+    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed']
     statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },

--- a/twiml/voice/sip/sip-10/sip-10.5.x.cs
+++ b/twiml/voice/sip/sip-10/sip-10.5.x.cs
@@ -15,13 +15,11 @@ class Example
         var sip = new Sip(
             new Uri("http://example.com"),
             "kate",
-            statusCallbackEvent: new List<Sip.EventEnum>(
-                new EventEnum[] {
-                    EventEnum.Initiated,
-                    EventEnum.Ringing,
-                    EventEnum.Answered,
-                    EventEnum.Completed
-                }
+            statusCallbackEvent: new List<EventEnum>(
+                EventEnum.Initiated,
+                EventEnum.Ringing,
+                EventEnum.Answered,
+                EventEnum.Completed
             ),
             statusCallback: new Uri("https://myapp.com/calls/events"),
             statusCallbackMethod: HttpMethod.Post

--- a/twiml/voice/sip/sip-10/sip-10.5.x.php
+++ b/twiml/voice/sip/sip-10/sip-10.5.x.php
@@ -5,7 +5,7 @@ use Twilio\TwiML;
 $response = new TwiML();
 $dial = $response->dial();
 $dial->sip('sip:kate@example.com',
-    ['statusCallbackEvent' => 'initiated ringing answered completed',
+    ['statusCallbackEvent' => array('initiated', 'ringing', 'answered', 'completed'),
     'statusCallback' => 'https://myapp.com/calls/events',
     'statusCallbackMethod' => 'POST']);
 

--- a/twiml/voice/sip/sip-10/sip-10.6.x.py
+++ b/twiml/voice/sip/sip-10/sip-10.6.x.py
@@ -4,7 +4,7 @@ response = VoiceResponse()
 dial = Dial()
 dial.sip(
     'sip:kate@example.com',
-    status_callback_event='initiated ringing answered completed',
+    status_callback_event=['initiated', 'ringing', 'answered', 'completed'],
     status_callback='https://myapp.com/calls/events',
     status_callback_method='POST'
 )

--- a/twiml/voice/sip/sip-10/sip-10.7.x.java
+++ b/twiml/voice/sip/sip-10/sip-10.7.x.java
@@ -5,14 +5,23 @@ import com.twilio.twiml.TwiMLException;
 import com.twilio.twiml.voice.Sip.Event;
 import com.twilio.http.HttpMethod;
 import java.util.Arrays;
+import java.util.List;
 
 public class Example {
     public static void main(String[] args) {
+        List<Event> events = Arrays.asList(
+            Event.INITIATED,
+            Event.RINGING,
+            Event.ANSWERED,
+            Event.COMPLETED
+        );
+
         Sip sip = new Sip.Builder("sip:kate@example.com")
             .statusCallback("https://myapp.com/calls/events")
-            .statusCallbackMethod(HttpMethod.POST).statusCallbackEvents(Arrays
-            .asList(Event.INITIATED, Event.RINGING, Event.ANSWERED, Event
-            .COMPLETED)).build();
+            .statusCallbackMethod(HttpMethod.POST)
+            .statusCallbackEvents(events)
+            .build();
+
         Dial dial = new Dial.Builder().sip(sip).build();
         VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
 


### PR DESCRIPTION
This PR only updates snippets to use correct format and type for each helper library. A separate PR should be made once helper libraries are updated to force all helper libraries to use enums for status events in all resources instead. 