### PR TITLE
Fix statusCallbackEvent property initialization

### DIFF
--- a/twiml/voice/number/number-3/number-3.3.x.js
+++ b/twiml/voice/number/number-3/number-3.3.x.js
@@ -4,7 +4,7 @@ const response = new VoiceResponse();
 const dial = response.dial();
 dial.number(
   {
-    statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed']
+    statusCallbackEvent: 'initiated ringing answered completed',
     statusCallback: 'https://myapp.com/calls/events',
     statusCallbackMethod: 'POST',
   },


### PR DESCRIPTION
When the statusCallbackEvent initializer is an array, `toString()` produces a comma-delimited string instead of a space-delimited string, which is required for event specification. The existing example also did not have a comma after the statusCallbackEvent property initializer.