### PR TITLE
API snippets to generate TwiML with <Pay> verb and <Prompt> noun usage

### DIFF
--- a/twiml/voice/pay/pay-3/pay-3.5.x.cs
+++ b/twiml/voice/pay/pay-3/pay-3.5.x.cs
@@ -1,3 +1,4 @@
+using System;
 using Twilio.TwiML;
 using Twilio.TwiML.Voice;
 
@@ -8,7 +9,7 @@ class Example
     {
         var response = new VoiceResponse();
         response.Say("Calling Twilio Pay");
-        response.Pay(chargeAmount: "20.45", action: "https://enter-your-callback-function-url.twil.io/pay");
+        response.Pay(chargeAmount: "20.45", action: new Uri("https://enter-your-callback-function-url.twil.io/pay"));
 
         System.Console.WriteLine(response.ToString());
     }

--- a/twiml/voice/pay/pay-5/meta.json
+++ b/twiml/voice/pay/pay-5/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Capture payment with prompt for card number and audio play",
+  "type": "server"
+}

--- a/twiml/voice/pay/pay-5/output/pay_prompt_card_number_play.xml
+++ b/twiml/voice/pay/pay-5/output/pay_prompt_card_number_play.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pay>
+   <Prompt for="payment-card-number">
+     <Play>https://myurl.com/twilio/twiml/audio/card_number.mp3</Play>
+   </Prompt>
+  </Pay>
+</Response>

--- a/twiml/voice/pay/pay-5/pay-5.3.x.js
+++ b/twiml/voice/pay/pay-5/pay-5.3.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const pay = response.pay();
+const prompt = pay.prompt({
+    for: 'payment-card-number'
+});
+prompt.play('https://myurl.com/twilio/twiml/audio/card_number.mp3');
+
+console.log(response.toString());

--- a/twiml/voice/pay/pay-5/pay-5.5.x.cs
+++ b/twiml/voice/pay/pay-5/pay-5.5.x.cs
@@ -1,0 +1,19 @@
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var pay = new Pay();
+        var prompt = new Prompt(for_: "payment-card-number");
+        prompt.Play(new Uri("https://myurl.com/twilio/twiml/audio/card_number.mp3"));
+        pay.Append(prompt);
+        response.Append(pay);
+
+        System.Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/pay/pay-5/pay-5.5.x.php
+++ b/twiml/voice/pay/pay-5/pay-5.5.x.php
@@ -1,0 +1,10 @@
+<?php
+require_once 'vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$pay = $response->pay();
+$prompt = $pay->prompt(['for' => 'payment-card-number']);
+$prompt->play('https://myurl.com/twilio/twiml/audio/card_number.mp3');
+
+echo $response;

--- a/twiml/voice/pay/pay-5/pay-5.5.x.rb
+++ b/twiml/voice/pay/pay-5/pay-5.5.x.rb
@@ -4,7 +4,7 @@ response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'payment-card-number') do |prompt|
         prompt.play(url: 'https://myurl.com/twilio/twiml/audio/card_number.mp3')
-end
+    end
 end
 
 puts response

--- a/twiml/voice/pay/pay-5/pay-5.5.x.rb
+++ b/twiml/voice/pay/pay-5/pay-5.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.pay do |pay|
+    pay.prompt(for: 'payment-card-number') do |prompt|
+        prompt.play(url: 'https://myurl.com/twilio/twiml/audio/card_number.mp3')
+end
+end
+
+puts response

--- a/twiml/voice/pay/pay-5/pay-5.6.x.py
+++ b/twiml/voice/pay/pay-5/pay-5.6.x.py
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Pay, Play, Prompt, VoiceResponse
+
+response = VoiceResponse()
+pay = Pay()
+prompt = Prompt(for_='payment-card-number')
+prompt.play('https://myurl.com/twilio/twiml/audio/card_number.mp3')
+pay.append(prompt)
+response.append(pay)
+
+print(response)

--- a/twiml/voice/pay/pay-5/pay-5.7.x.java
+++ b/twiml/voice/pay/pay-5/pay-5.7.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Pay;
+import com.twilio.twiml.voice.Play;
+import com.twilio.twiml.voice.Prompt;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Play play = new Play.Builder("https://myurl.com/twilio/twiml/audio/card_number.mp3").build();
+        Prompt prompt = new Prompt.Builder().for_(Prompt.For.PAYMENT_CARD_NUMBER).play(play).build();
+        Pay pay = new Pay.Builder().prompt(prompt).build();
+        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/pay/pay-6/meta.json
+++ b/twiml/voice/pay/pay-6/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Capture payment with prompt for card number",
+  "type": "server"
+}

--- a/twiml/voice/pay/pay-6/output/pay_prompt_card_number_say.xml
+++ b/twiml/voice/pay/pay-6/output/pay_prompt_card_number_say.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pay>
+   <Prompt for="payment-card-number">
+     <Say>Please enter your 15 digit visa or master card number.</Say>
+   </Prompt>
+  </Pay>
+</Response>

--- a/twiml/voice/pay/pay-6/output/pay_prompt_card_number_say.xml
+++ b/twiml/voice/pay/pay-6/output/pay_prompt_card_number_say.xml
@@ -2,7 +2,7 @@
 <Response>
   <Pay>
    <Prompt for="payment-card-number">
-     <Say>Please enter your 15 digit visa or master card number.</Say>
+     <Say>Please enter your 15 digit Visa or Mastercard number.</Say>
    </Prompt>
   </Pay>
 </Response>

--- a/twiml/voice/pay/pay-6/pay-6.3.x.js
+++ b/twiml/voice/pay/pay-6/pay-6.3.x.js
@@ -5,6 +5,6 @@ const pay = response.pay();
 const prompt = pay.prompt({
     for: 'payment-card-number'
 });
-prompt.say('Please enter your 15 digit visa or master card number.');
+prompt.say('Please enter your 15 digit Visa or Mastercard number.');
 
 console.log(response.toString());

--- a/twiml/voice/pay/pay-6/pay-6.3.x.js
+++ b/twiml/voice/pay/pay-6/pay-6.3.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const pay = response.pay();
+const prompt = pay.prompt({
+    for: 'payment-card-number'
+});
+prompt.say('Please enter your 15 digit visa or master card number.');
+
+console.log(response.toString());

--- a/twiml/voice/pay/pay-6/pay-6.5.x.cs
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.cs
@@ -1,0 +1,18 @@
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var pay = new Pay();
+        var prompt = new Prompt(for_: "payment-card-number");
+        prompt.Say("Please enter your 15 digit visa or master card number.");
+        pay.Append(prompt);
+        response.Append(pay);
+
+        System.Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/pay/pay-6/pay-6.5.x.cs
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.cs
@@ -9,7 +9,7 @@ class Example
         var response = new VoiceResponse();
         var pay = new Pay();
         var prompt = new Prompt(for_: "payment-card-number");
-        prompt.Say("Please enter your 15 digit visa or master card number.");
+        prompt.Say("Please enter your 15 digit Visa or Mastercard number.");
         pay.Append(prompt);
         response.Append(pay);
 

--- a/twiml/voice/pay/pay-6/pay-6.5.x.php
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.php
@@ -1,0 +1,10 @@
+<?php
+require_once 'vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$pay = $response->pay();
+$prompt = $pay->prompt(['for' => 'payment-card-number']);
+$prompt->say('Please enter your 15 digit visa or master card number.');
+
+echo $response;

--- a/twiml/voice/pay/pay-6/pay-6.5.x.php
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.php
@@ -5,6 +5,6 @@ use Twilio\TwiML\VoiceResponse;
 $response = new VoiceResponse();
 $pay = $response->pay();
 $prompt = $pay->prompt(['for' => 'payment-card-number']);
-$prompt->say('Please enter your 15 digit visa or master card number.');
+$prompt->say('Please enter your 15 digit Visa or Mastercard number.');
 
 echo $response;

--- a/twiml/voice/pay/pay-6/pay-6.5.x.rb
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.pay do |pay|
+    pay.prompt(for: 'payment-card-number') do |prompt|
+        prompt.say(message: 'Please enter your 15 digit visa or master card number.')
+end
+end
+
+puts response

--- a/twiml/voice/pay/pay-6/pay-6.5.x.rb
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.rb
@@ -3,7 +3,7 @@ require 'twilio-ruby'
 response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'payment-card-number') do |prompt|
-        prompt.say(message: 'Please enter your 15 digit visa or master card number.')
+        prompt.say(message: 'Please enter your 15 digit Visa or Mastercard number.')
     end
 end
 

--- a/twiml/voice/pay/pay-6/pay-6.5.x.rb
+++ b/twiml/voice/pay/pay-6/pay-6.5.x.rb
@@ -4,7 +4,7 @@ response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'payment-card-number') do |prompt|
         prompt.say(message: 'Please enter your 15 digit visa or master card number.')
-end
+    end
 end
 
 puts response

--- a/twiml/voice/pay/pay-6/pay-6.6.x.py
+++ b/twiml/voice/pay/pay-6/pay-6.6.x.py
@@ -3,7 +3,7 @@ from twilio.twiml.voice_response import Pay, Prompt, VoiceResponse, Say
 response = VoiceResponse()
 pay = Pay()
 prompt = Prompt(for_='payment-card-number')
-prompt.say('Please enter your 15 digit visa or master card number.')
+prompt.say('Please enter your 15 digit Visa or Mastercard number.')
 pay.append(prompt)
 response.append(pay)
 

--- a/twiml/voice/pay/pay-6/pay-6.6.x.py
+++ b/twiml/voice/pay/pay-6/pay-6.6.x.py
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Pay, Prompt, VoiceResponse, Say
+
+response = VoiceResponse()
+pay = Pay()
+prompt = Prompt(for_='payment-card-number')
+prompt.say('Please enter your 15 digit visa or master card number.')
+pay.append(prompt)
+response.append(pay)
+
+print(response)

--- a/twiml/voice/pay/pay-6/pay-6.7.x.java
+++ b/twiml/voice/pay/pay-6/pay-6.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 
 public class Example {
     public static void main(String[] args) {
-        Say say = new Say.Builder("Please enter your 15 digit visa or master card number.").build();
+        Say say = new Say.Builder("Please enter your 15 digit Visa or Mastercard number.").build();
         Prompt prompt = new Prompt.Builder().for_(Prompt.For.PAYMENT_CARD_NUMBER).say(say).build();
         Pay pay = new Pay.Builder().prompt(prompt).build();
         VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

--- a/twiml/voice/pay/pay-6/pay-6.7.x.java
+++ b/twiml/voice/pay/pay-6/pay-6.7.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Pay;
+import com.twilio.twiml.voice.Prompt;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.voice.Say;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Say say = new Say.Builder("Please enter your 15 digit visa or master card number.").build();
+        Prompt prompt = new Prompt.Builder().for_(Prompt.For.PAYMENT_CARD_NUMBER).say(say).build();
+        Pay pay = new Pay.Builder().prompt(prompt).build();
+        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/pay/pay-7/meta.json
+++ b/twiml/voice/pay/pay-7/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Capture payment with prompt for security code and card type",
+  "type": "server"
+}

--- a/twiml/voice/pay/pay-7/output/pay_prompt_card_type_amex.xml
+++ b/twiml/voice/pay/pay-7/output/pay_prompt_card_type_amex.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pay>
+   <Prompt for="security-code" cardType="amex">
+     <Say>
+      Please enter security code for your American Express card. It’s the 4 digits located in the front of your card
+     </Say>
+   </Prompt>
+  </Pay>
+</Response>

--- a/twiml/voice/pay/pay-7/output/pay_prompt_card_type_amex.xml
+++ b/twiml/voice/pay/pay-7/output/pay_prompt_card_type_amex.xml
@@ -3,7 +3,7 @@
   <Pay>
    <Prompt for="security-code" cardType="amex">
      <Say>
-      Please enter security code for your American Express card. It’s the 4 digits located in the front of your card
+      Please enter security code for your American Express card. It’s the 4 digits located on the front of your card
      </Say>
    </Prompt>
   </Pay>

--- a/twiml/voice/pay/pay-7/pay-7.3.x.js
+++ b/twiml/voice/pay/pay-7/pay-7.3.x.js
@@ -1,0 +1,11 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const pay = response.pay();
+const prompt = pay.prompt({
+    for: 'security-code',
+    cardType: 'amex'
+});
+prompt.say('Please enter security code for your American Express card. It’s the 4 digits located in the front of your card');
+
+console.log(response.toString());

--- a/twiml/voice/pay/pay-7/pay-7.3.x.js
+++ b/twiml/voice/pay/pay-7/pay-7.3.x.js
@@ -6,6 +6,6 @@ const prompt = pay.prompt({
     for: 'security-code',
     cardType: 'amex'
 });
-prompt.say('Please enter security code for your American Express card. It’s the 4 digits located in the front of your card');
+prompt.say('Please enter security code for your American Express card. It’s the 4 digits located on the front of your card');
 
 console.log(response.toString());

--- a/twiml/voice/pay/pay-7/pay-7.5.x.cs
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.cs
@@ -10,7 +10,7 @@ class Example
         var response = new VoiceResponse();
         var pay = new Pay();
         var prompt = new Prompt(cardType: new []{Prompt.CardTypeEnum.Amex}.ToList(), for_: "security-code");
-        prompt.Say("Please enter security code for your American Express card. It’s the 4 digits located in the front of your card");
+        prompt.Say("Please enter security code for your American Express card. It’s the 4 digits located on the front of your card");
         pay.Append(prompt);
         response.Append(pay);
 

--- a/twiml/voice/pay/pay-7/pay-7.5.x.cs
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.cs
@@ -1,0 +1,19 @@
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+using System.Linq;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var pay = new Pay();
+        var prompt = new Prompt(cardType: new []{Prompt.CardTypeEnum.Amex}.ToList(), for_: "security-code");
+        prompt.Say("Please enter security code for your American Express card. It’s the 4 digits located in the front of your card");
+        pay.Append(prompt);
+        response.Append(pay);
+
+        System.Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/pay/pay-7/pay-7.5.x.php
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.php
@@ -5,6 +5,6 @@ use Twilio\TwiML\VoiceResponse;
 $response = new VoiceResponse();
 $pay = $response->pay();
 $prompt = $pay->prompt(['for' => 'security-code', 'cardType' => 'amex']);
-$prompt->say('Please enter security code for your American Express card. It’s the 4 digits located in the front of your card');
+$prompt->say('Please enter security code for your American Express card. It’s the 4 digits located on the front of your card');
 
 echo $response;

--- a/twiml/voice/pay/pay-7/pay-7.5.x.php
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.php
@@ -1,0 +1,10 @@
+<?php
+require_once 'vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$pay = $response->pay();
+$prompt = $pay->prompt(['for' => 'security-code', 'cardType' => 'amex']);
+$prompt->say('Please enter security code for your American Express card. It’s the 4 digits located in the front of your card');
+
+echo $response;

--- a/twiml/voice/pay/pay-7/pay-7.5.x.rb
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.pay do |pay|
+    pay.prompt(for: 'security-code', cardType: 'amex') do |prompt|
+        prompt.say(message: 'Please enter security code for your American Express card. It’s the 4 digits located in the front of your card')
+end
+end
+
+puts response

--- a/twiml/voice/pay/pay-7/pay-7.5.x.rb
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.rb
@@ -4,7 +4,7 @@ response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'security-code', cardType: 'amex') do |prompt|
         prompt.say(message: 'Please enter security code for your American Express card. It’s the 4 digits located in the front of your card')
-end
+    end
 end
 
 puts response

--- a/twiml/voice/pay/pay-7/pay-7.5.x.rb
+++ b/twiml/voice/pay/pay-7/pay-7.5.x.rb
@@ -3,7 +3,7 @@ require 'twilio-ruby'
 response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'security-code', cardType: 'amex') do |prompt|
-        prompt.say(message: 'Please enter security code for your American Express card. It’s the 4 digits located in the front of your card')
+        prompt.say(message: 'Please enter security code for your American Express card. It’s the 4 digits located on the front of your card')
     end
 end
 

--- a/twiml/voice/pay/pay-7/pay-7.6.x.py
+++ b/twiml/voice/pay/pay-7/pay-7.6.x.py
@@ -1,0 +1,12 @@
+from twilio.twiml.voice_response import Pay, Prompt, VoiceResponse, Say
+
+response = VoiceResponse()
+pay = Pay()
+prompt = Prompt(card_type='amex', for_='security-code')
+prompt.say(
+    'Please enter security code for your American Express card. It’s the 4 digits located in the front of your card'
+)
+pay.append(prompt)
+response.append(pay)
+
+print(response)

--- a/twiml/voice/pay/pay-7/pay-7.6.x.py
+++ b/twiml/voice/pay/pay-7/pay-7.6.x.py
@@ -4,7 +4,7 @@ response = VoiceResponse()
 pay = Pay()
 prompt = Prompt(card_type='amex', for_='security-code')
 prompt.say(
-    'Please enter security code for your American Express card. It’s the 4 digits located in the front of your card'
+    'Please enter security code for your American Express card. It’s the 4 digits located on the front of your card'
 )
 pay.append(prompt)
 response.append(pay)

--- a/twiml/voice/pay/pay-7/pay-7.7.x.java
+++ b/twiml/voice/pay/pay-7/pay-7.7.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Pay;
+import com.twilio.twiml.voice.Prompt;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.voice.Say;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Say say = new Say.Builder("Please enter security code for your American Express card. It’s the 4 digits located in the front of your card").build();
+        Prompt prompt = new Prompt.Builder().cardTypes(Prompt.CardType.AMEX).for_(Prompt.For.SECURITY_CODE).say(say).build();
+        Pay pay = new Pay.Builder().prompt(prompt).build();
+        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/pay/pay-7/pay-7.7.x.java
+++ b/twiml/voice/pay/pay-7/pay-7.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 
 public class Example {
     public static void main(String[] args) {
-        Say say = new Say.Builder("Please enter security code for your American Express card. It’s the 4 digits located in the front of your card").build();
+        Say say = new Say.Builder("Please enter security code for your American Express card. It’s the 4 digits located on the front of your card").build();
         Prompt prompt = new Prompt.Builder().cardTypes(Prompt.CardType.AMEX).for_(Prompt.For.SECURITY_CODE).say(say).build();
         Pay pay = new Pay.Builder().prompt(prompt).build();
         VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

--- a/twiml/voice/pay/pay-8/meta.json
+++ b/twiml/voice/pay/pay-8/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Capture payment with prompt for security code and card type",
+  "type": "server"
+}

--- a/twiml/voice/pay/pay-8/output/pay_prompt_card_type_visa.xml
+++ b/twiml/voice/pay/pay-8/output/pay_prompt_card_type_visa.xml
@@ -2,7 +2,7 @@
 <Response>
   <Pay>
    <Prompt for="security-code" cardType="visa">
-     <Say> Please enter security code for your visa card. It’s the 3 digits located in the back of your card </Say>
+     <Say> Please enter security code for your Visa card. It’s the 3 digits located on the back of your card </Say>
    </Prompt>
   </Pay>
 </Response>

--- a/twiml/voice/pay/pay-8/output/pay_prompt_card_type_visa.xml
+++ b/twiml/voice/pay/pay-8/output/pay_prompt_card_type_visa.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pay>
+   <Prompt for="security-code" cardType="visa">
+     <Say> Please enter security code for your visa card. It’s the 3 digits located in the back of your card </Say>
+   </Prompt>
+  </Pay>
+</Response>

--- a/twiml/voice/pay/pay-8/pay-8.3.x.js
+++ b/twiml/voice/pay/pay-8/pay-8.3.x.js
@@ -1,0 +1,11 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const pay = response.pay();
+const prompt = pay.prompt({
+    for: 'security-code',
+    cardType: 'visa'
+});
+prompt.say('Please enter security code for your visa card. It’s the 3 digits located in the back of your card');
+
+console.log(response.toString());

--- a/twiml/voice/pay/pay-8/pay-8.3.x.js
+++ b/twiml/voice/pay/pay-8/pay-8.3.x.js
@@ -6,6 +6,6 @@ const prompt = pay.prompt({
     for: 'security-code',
     cardType: 'visa'
 });
-prompt.say('Please enter security code for your visa card. It’s the 3 digits located in the back of your card');
+prompt.say('Please enter security code for your Visa card. It’s the 3 digits located on the back of your card');
 
 console.log(response.toString());

--- a/twiml/voice/pay/pay-8/pay-8.5.x.cs
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.cs
@@ -1,0 +1,19 @@
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+using System.Linq;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var pay = new Pay();
+        var prompt = new Prompt(cardType: new []{Prompt.CardTypeEnum.Visa}.ToList(), for_: "security-code");
+        prompt.Say("Please enter security code for your visa card. It’s the 3 digits located in the back of your card");
+        pay.Append(prompt);
+        response.Append(pay);
+
+        System.Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/pay/pay-8/pay-8.5.x.cs
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.cs
@@ -10,7 +10,7 @@ class Example
         var response = new VoiceResponse();
         var pay = new Pay();
         var prompt = new Prompt(cardType: new []{Prompt.CardTypeEnum.Visa}.ToList(), for_: "security-code");
-        prompt.Say("Please enter security code for your visa card. It’s the 3 digits located in the back of your card");
+        prompt.Say("Please enter security code for your Visa card. It’s the 3 digits located on the back of your card");
         pay.Append(prompt);
         response.Append(pay);
 

--- a/twiml/voice/pay/pay-8/pay-8.5.x.php
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.php
@@ -1,0 +1,10 @@
+<?php
+require_once 'vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$pay = $response->pay();
+$prompt = $pay->prompt(['for' => 'security-code', 'cardType' => 'visa']);
+$prompt->say('Please enter security code for your visa card. It’s the 3 digits located in the back of your card');
+
+echo $response;

--- a/twiml/voice/pay/pay-8/pay-8.5.x.php
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.php
@@ -5,6 +5,6 @@ use Twilio\TwiML\VoiceResponse;
 $response = new VoiceResponse();
 $pay = $response->pay();
 $prompt = $pay->prompt(['for' => 'security-code', 'cardType' => 'visa']);
-$prompt->say('Please enter security code for your visa card. It’s the 3 digits located in the back of your card');
+$prompt->say('Please enter security code for your Visa card. It’s the 3 digits located on the back of your card');
 
 echo $response;

--- a/twiml/voice/pay/pay-8/pay-8.5.x.rb
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.rb
@@ -4,7 +4,7 @@ response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'security-code', cardType: 'visa') do |prompt|
         prompt.say(message: 'Please enter security code for your visa card. It’s the 3 digits located in the back of your card')
-end
+    end
 end
 
 puts response

--- a/twiml/voice/pay/pay-8/pay-8.5.x.rb
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.pay do |pay|
+    pay.prompt(for: 'security-code', cardType: 'visa') do |prompt|
+        prompt.say(message: 'Please enter security code for your visa card. It’s the 3 digits located in the back of your card')
+end
+end
+
+puts response

--- a/twiml/voice/pay/pay-8/pay-8.5.x.rb
+++ b/twiml/voice/pay/pay-8/pay-8.5.x.rb
@@ -3,7 +3,7 @@ require 'twilio-ruby'
 response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'security-code', cardType: 'visa') do |prompt|
-        prompt.say(message: 'Please enter security code for your visa card. It’s the 3 digits located in the back of your card')
+        prompt.say(message: 'Please enter security code for your Visa card. It’s the 3 digits located on the back of your card')
     end
 end
 

--- a/twiml/voice/pay/pay-8/pay-8.6.x.py
+++ b/twiml/voice/pay/pay-8/pay-8.6.x.py
@@ -4,7 +4,7 @@ response = VoiceResponse()
 pay = Pay()
 prompt = Prompt(card_type='visa', for_='security-code')
 prompt.say(
-    'Please enter security code for your visa card. It’s the 3 digits located in the back of your card'
+    'Please enter security code for your Visa card. It’s the 3 digits located on the back of your card'
 )
 pay.append(prompt)
 response.append(pay)

--- a/twiml/voice/pay/pay-8/pay-8.6.x.py
+++ b/twiml/voice/pay/pay-8/pay-8.6.x.py
@@ -1,0 +1,12 @@
+from twilio.twiml.voice_response import Pay, Prompt, VoiceResponse, Say
+
+response = VoiceResponse()
+pay = Pay()
+prompt = Prompt(card_type='visa', for_='security-code')
+prompt.say(
+    'Please enter security code for your visa card. It’s the 3 digits located in the back of your card'
+)
+pay.append(prompt)
+response.append(pay)
+
+print(response)

--- a/twiml/voice/pay/pay-8/pay-8.7.x.java
+++ b/twiml/voice/pay/pay-8/pay-8.7.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Pay;
+import com.twilio.twiml.voice.Prompt;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.voice.Say;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Say say = new Say.Builder("Please enter security code for your visa card. It’s the 3 digits located in the back of your card").build();
+        Prompt prompt = new Prompt.Builder().cardTypes(Prompt.CardType.VISA).for_(Prompt.For.SECURITY_CODE).say(say).build();
+        Pay pay = new Pay.Builder().prompt(prompt).build();
+        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/pay/pay-8/pay-8.7.x.java
+++ b/twiml/voice/pay/pay-8/pay-8.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 
 public class Example {
     public static void main(String[] args) {
-        Say say = new Say.Builder("Please enter security code for your visa card. It’s the 3 digits located in the back of your card").build();
+        Say say = new Say.Builder("Please enter security code for your Visa card. It’s the 3 digits located on the back of your card").build();
         Prompt prompt = new Prompt.Builder().cardTypes(Prompt.CardType.VISA).for_(Prompt.For.SECURITY_CODE).say(say).build();
         Pay pay = new Pay.Builder().prompt(prompt).build();
         VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

--- a/twiml/voice/pay/pay-9/meta.json
+++ b/twiml/voice/pay/pay-9/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Capture payment with prompt for expiration date counting attempts",
+  "type": "server"
+}

--- a/twiml/voice/pay/pay-9/output/pay_prompt_expiration_date_attempts.xml
+++ b/twiml/voice/pay/pay-9/output/pay_prompt_expiration_date_attempts.xml
@@ -5,7 +5,7 @@
     <Say> Please enter your expiration date, two digits for the month and two digits for the year.</Say>
   </Prompt>
   <Prompt for="expiration-date" attempt="2 3">
-    <Say> Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2 </Say>
+    <Say> Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2 </Say>
   </Prompt>
  </Pay>
 </Response>

--- a/twiml/voice/pay/pay-9/output/pay_prompt_expiration_date_attempts.xml
+++ b/twiml/voice/pay/pay-9/output/pay_prompt_expiration_date_attempts.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+ <Pay>
+  <Prompt for="expiration-date" attempt="1">
+    <Say> Please enter your expiration date, two digits for the month and two digits for the year.</Say>
+  </Prompt>
+  <Prompt for="expiration-date" attempt="2 3">
+    <Say> Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2 </Say>
+  </Prompt>
+ </Pay>
+</Response>

--- a/twiml/voice/pay/pay-9/pay-9.3.x.js
+++ b/twiml/voice/pay/pay-9/pay-9.3.x.js
@@ -12,6 +12,6 @@ const prompt2 = pay.prompt({
     for: 'expiration-date',
     attempt: '2 3'
 });
-prompt2.say('Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2');
+prompt2.say('Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2');
 
 console.log(response.toString());

--- a/twiml/voice/pay/pay-9/pay-9.3.x.js
+++ b/twiml/voice/pay/pay-9/pay-9.3.x.js
@@ -1,0 +1,17 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+
+const response = new VoiceResponse();
+const pay = response.pay();
+const prompt = pay.prompt({
+    for: 'expiration-date',
+    attempt: '1'
+});
+prompt.say('Please enter your expiration date, two digits for the month and two digits for the year.');
+const prompt2 = pay.prompt({
+    for: 'expiration-date',
+    attempt: '2 3'
+});
+prompt2.say('Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2');
+
+console.log(response.toString());

--- a/twiml/voice/pay/pay-9/pay-9.5.x.cs
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.cs
@@ -13,7 +13,7 @@ class Example
         prompt.Say("Please enter your expiration date, two digits for the month and two digits for the year.");
         pay.Append(prompt);
         var prompt2 = new Prompt(attempt: new []{2, 3}.ToList(), for_: "expiration-date");
-        prompt2.Say("Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2");
+        prompt2.Say("Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2");
         pay.Append(prompt2);
         response.Append(pay);
 

--- a/twiml/voice/pay/pay-9/pay-9.5.x.cs
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.cs
@@ -1,0 +1,22 @@
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+using System.Linq;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var pay = new Pay();
+        var prompt = new Prompt(attempt: new []{1}.ToList(), for_: "expiration-date");
+        prompt.Say("Please enter your expiration date, two digits for the month and two digits for the year.");
+        pay.Append(prompt);
+        var prompt2 = new Prompt(attempt: new []{2, 3}.ToList(), for_: "expiration-date");
+        prompt2.Say("Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2");
+        pay.Append(prompt2);
+        response.Append(pay);
+
+        System.Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/pay/pay-9/pay-9.5.x.php
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.php
@@ -7,6 +7,6 @@ $pay = $response->pay();
 $prompt = $pay->prompt(['for' => 'expiration-date', 'attempt' => '1']);
 $prompt->say('Please enter your expiration date, two digits for the month and two digits for the year.');
 $prompt2 = $pay->prompt(['for' => 'expiration-date', 'attempt' => '2 3']);
-$prompt2->say('Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2');
+$prompt2->say('Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2');
 
 echo $response;

--- a/twiml/voice/pay/pay-9/pay-9.5.x.php
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.php
@@ -1,0 +1,12 @@
+<?php
+require_once 'vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$pay = $response->pay();
+$prompt = $pay->prompt(['for' => 'expiration-date', 'attempt' => '1']);
+$prompt->say('Please enter your expiration date, two digits for the month and two digits for the year.');
+$prompt2 = $pay->prompt(['for' => 'expiration-date', 'attempt' => '2 3']);
+$prompt2->say('Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2');
+
+echo $response;

--- a/twiml/voice/pay/pay-9/pay-9.5.x.rb
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.rb
@@ -1,0 +1,13 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.pay do |pay|
+    pay.prompt(for: 'expiration-date', attempt: '1') do |prompt|
+        prompt.say(message: 'Please enter your expiration date, two digits for the month and two digits for the year.')
+end
+    pay.prompt(for: 'expiration-date', attempt: '2 3') do |prompt|
+        prompt.say(message: 'Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2')
+end
+end
+
+puts response

--- a/twiml/voice/pay/pay-9/pay-9.5.x.rb
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.rb
@@ -4,10 +4,10 @@ response = Twilio::TwiML::VoiceResponse.new
 response.pay do |pay|
     pay.prompt(for: 'expiration-date', attempt: '1') do |prompt|
         prompt.say(message: 'Please enter your expiration date, two digits for the month and two digits for the year.')
-end
+    end
     pay.prompt(for: 'expiration-date', attempt: '2 3') do |prompt|
         prompt.say(message: 'Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2')
-end
+    end
 end
 
 puts response

--- a/twiml/voice/pay/pay-9/pay-9.5.x.rb
+++ b/twiml/voice/pay/pay-9/pay-9.5.x.rb
@@ -6,7 +6,7 @@ response.pay do |pay|
         prompt.say(message: 'Please enter your expiration date, two digits for the month and two digits for the year.')
     end
     pay.prompt(for: 'expiration-date', attempt: '2 3') do |prompt|
-        prompt.say(message: 'Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2')
+        prompt.say(message: 'Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2')
     end
 end
 

--- a/twiml/voice/pay/pay-9/pay-9.6.x.py
+++ b/twiml/voice/pay/pay-9/pay-9.6.x.py
@@ -1,0 +1,17 @@
+from twilio.twiml.voice_response import Pay, Prompt, VoiceResponse, Say
+
+response = VoiceResponse()
+pay = Pay()
+prompt = Prompt(attempt='1', for_='expiration-date')
+prompt.say(
+    'Please enter your expiration date, two digits for the month and two digits for the year.'
+)
+pay.append(prompt)
+prompt2 = Prompt(attempt='2 3', for_='expiration-date')
+prompt2.say(
+    'Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2'
+)
+pay.append(prompt2)
+response.append(pay)
+
+print(response)

--- a/twiml/voice/pay/pay-9/pay-9.6.x.py
+++ b/twiml/voice/pay/pay-9/pay-9.6.x.py
@@ -9,7 +9,7 @@ prompt.say(
 pay.append(prompt)
 prompt2 = Prompt(attempt='2 3', for_='expiration-date')
 prompt2.say(
-    'Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2'
+    'Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2'
 )
 pay.append(prompt2)
 response.append(pay)

--- a/twiml/voice/pay/pay-9/pay-9.7.x.java
+++ b/twiml/voice/pay/pay-9/pay-9.7.x.java
@@ -9,7 +9,7 @@ public class Example {
     public static void main(String[] args) {
         Say say = new Say.Builder("Please enter your expiration date, two digits for the month and two digits for the year.").build();
         Prompt prompt = new Prompt.Builder().attempts(1).for_(Prompt.For.EXPIRATION_DATE).say(say).build();
-        Say say2 = new Say.Builder("Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2").build();
+        Say say2 = new Say.Builder("Please enter your expiration date, two digits for the month and two digits for the year. For example, if your expiration date is March 2022, then please enter 0 3 2 2").build();
         Prompt prompt2 = new Prompt.Builder().attempts(Arrays.asList(2, 3)).for_(Prompt.For.EXPIRATION_DATE).say(say2).build();
         Pay pay = new Pay.Builder().prompt(prompt).prompt(prompt2).build();
         VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

--- a/twiml/voice/pay/pay-9/pay-9.7.x.java
+++ b/twiml/voice/pay/pay-9/pay-9.7.x.java
@@ -1,0 +1,23 @@
+import com.twilio.twiml.voice.Pay;
+import com.twilio.twiml.voice.Prompt;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.voice.Say;
+import com.twilio.twiml.TwiMLException;
+import java.util.Arrays;
+
+public class Example {
+    public static void main(String[] args) {
+        Say say = new Say.Builder("Please enter your expiration date, two digits for the month and two digits for the year.").build();
+        Prompt prompt = new Prompt.Builder().attempts(1).for_(Prompt.For.EXPIRATION_DATE).say(say).build();
+        Say say2 = new Say.Builder("Please enter your expiration date,  two digits for the month and two digits for the year. For exampe, if your expiration date is March 2022, then please enter 0 3 2 2").build();
+        Prompt prompt2 = new Prompt.Builder().attempts(Arrays.asList(2, 3)).for_(Prompt.For.EXPIRATION_DATE).say(say2).build();
+        Pay pay = new Pay.Builder().prompt(prompt).prompt(prompt2).build();
+        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Related to [DEVED-3546](https://issues.corp.twilio.com/browse/DEVED-3546)

### Issues found:
Java SDK: `Prompt.ErrorType.INVALID_POSTAL_CODE` no definition found
C# SDK:  `Prompt.ErrorTypeEnum.InvalidPostalCode` no definition found
Required to generate snippets for [last twiml in the page](https://www.twilio.com/docs/voice/twiml/pay/prompt#example), so snippets for this TwiML are missing.

TwiMLs in [this section](https://www.twilio.com/docs/voice/twiml/pay/prompt#cardtype) contain an incorrect closing tag as the following:
![screenshot from 2018-10-17 09-15-10](https://user-images.githubusercontent.com/21978742/47092744-49c67f80-d1ed-11e8-9694-e27b3118b728.png)
