### PR TITLE
added m2m_commands_feather32u4fona

### DIFF
--- a/wireless/quickstart/m2m_commands_arduino_sim800/SIM800Twilio.cpp
+++ b/wireless/quickstart/m2m_commands_arduino_sim800/SIM800Twilio.cpp
@@ -1,0 +1,210 @@
+#include "SIM800Twilio.hpp"
+
+/*
+ * Reserve storage space, begin Software Serial and reset the modem
+ */
+void SIM800Twilio::begin()
+{
+        _storage.reserve(512);
+        this->SoftwareSerial::begin(baud);
+        this->reset_modem();
+}
+
+/*
+ * Send 'AT' to the modem
+ */
+void SIM800Twilio::reset_modem()
+{
+        this->print("AT\r\n");
+        while (_read_serial().indexOf("OK") == -1) {
+                this->print("AT\r\n");
+        }
+        
+        delay(1000);
+
+        /* 
+         * Clear out any extra messages - depending on state,
+         * the module may send out Voice Ready/SMS Ready messages.
+         */
+
+        _read_serial();
+        _read_serial();
+}
+
+/*
+ * Find the next indexed message from short code 2936, which is a Twilio
+ * Machine to machine command.
+ * Inputs:
+ *  - m2m : Machine to machine command struct
+ *  - index : SMS index to start the search
+ *  - delete_non_twilio_msgs : To delete messages not from 2936
+ *
+ * Outputs:
+ *  - m2m : Populated command (if success)
+ *  - bool (method) : Whether a command was found
+ */
+bool SIM800Twilio::read_command(
+        M2MCommand &m2m, 
+        uint16_t index, 
+        bool delete_non_twilio_msgs)
+{
+        bool foundCommand = false;
+
+        while (1) {
+                String text = _read_SMS(index);
+                if (( text.indexOf("ERROR")) != -1 && text.length() < 20) {
+                        return false;
+                }
+
+                if (text.indexOf("OK") != -1 && text.length() < 20) {
+                        ++index;
+                        continue;
+                }
+        
+                /* Extract the number */         
+                int16_t p1 = text.indexOf(","); 
+                int16_t p2 = text.indexOf(",", p1+1);
+                
+                if (p1 == -1 || p2 == -1 || p1 == p2) {
+                        ++index;
+                        continue;
+                }
+
+                /* Check it is a Twilio Command from shortcode 2936*/
+                if (text.substring(p1+2, p2-1).indexOf("2936") == -1) {
+                        if (delete_non_twilio_msgs) {
+                                // Remove the message
+                                delete_SMS(index);
+                        }
+                        ++index;
+                        continue;
+                }
+
+                m2m.index = index;
+                
+                /* Extract the date */
+                p1 = text.indexOf(",", p2+1);
+        
+                if (p1 == -1 || p2 == -1 || p1 == p2) {
+                        ++index;
+                        continue;
+                }
+        
+                p1 = text.indexOf("\"", p1+1);
+                p2 = text.indexOf("\"", p1+1);
+        
+                m2m.date = text.substring(p1+1, p2-1);
+        
+                /* Extract the message */
+        
+                p1 = text.lastIndexOf("OK");
+                m2m.command = text.substring(p2+3, p1-4);
+                
+                return true;
+        }
+        
+        return false;
+}
+
+/*
+ * Send an SMS to short code 2936, which is a Twilio
+ * Machine to machine command.
+ * Inputs:
+ *  - command : String holding a command (keep it under 160 ASCII/67 UCS-2)
+ *
+ * Outputs:
+ *  - bool (method) : Whether a command was sent successfully
+ */
+bool SIM800Twilio::send_command(String command)
+{
+        return _send_SMS("2936", command);
+}
+
+/*
+ * Delete an SMS by index
+ * Inputs:
+ *  - index : The index of the SMS on the SIM800
+ *
+ * Outputs:
+ *  - bool (method) : Whether the SMS was deleted successfully
+ */
+bool SIM800Twilio::delete_SMS(uint16_t index)
+{
+        this->print("AT+CMGD=");
+        this->print(index);
+        this->print(",0\n\r");
+    
+        _storage=_read_serial();
+        if ( (_storage.indexOf("ERROR")) == -1) {
+                return false;
+        }
+    
+        return true;
+}
+
+bool SIM800Twilio::_send_SMS(String number, String message)
+{
+        this->print("AT+CMGF=1\r\n");
+        _storage=_read_serial();
+    
+        this->print("AT+CMGS=\"");
+        this->print(number);
+        this->print("\"\r\n");
+        _storage = _read_serial();
+    
+        this->print (message);
+        this->print ("\r\n");
+        _storage = _read_serial();
+
+        /* EOM character ^Z */
+        this->write(0x1A);
+        _storage=_read_serial(SEND_SMS_TIMEOUT);
+
+    
+        if (_storage.indexOf("ERROR") == -1) {
+                return false;
+        }
+    
+        return true;
+}
+
+String SIM800Twilio::_read_SMS(uint8_t index)
+{
+
+        this->print ("AT+CMGF=1\r");
+
+        if (( _read_serial().indexOf("ERROR")) == -1) {
+                this->print ("AT+CMGR=");
+                this->print (index);
+                this->print ("\r");
+                _storage = _read_serial();
+                
+                if (_storage.indexOf("+CMGR")!=-1) {
+                        return _storage;
+                } else {
+                        return "";
+                }
+
+                return "";
+        }
+}
+
+String SIM800Twilio::_read_serial(int16_t timeout)
+{
+        for (int i = 0; i < 100; ++i ) {
+                if (this->available()) break;
+                delay(50);
+        }
+    
+        String temp;
+
+        uint64_t last_char = millis();
+        while (millis() < last_char + timeout) {
+                if (this->available()) {
+                        temp += (char) this->read();
+                        last_char = millis();
+                }
+        }
+    
+        return temp;
+}

--- a/wireless/quickstart/m2m_commands_arduino_sim800/SIM800Twilio.hpp
+++ b/wireless/quickstart/m2m_commands_arduino_sim800/SIM800Twilio.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <SoftwareSerial.h>
+#include "Arduino.h"
+
+#define READ_SMS_TIMEOUT    1000  // 1 Second
+#define SEND_SMS_TIMEOUT    30000 // 30 Second
+
+struct M2MCommand
+{
+        int16_t index;
+        String date;
+        String command;
+};
+
+class SIM800Twilio : public SoftwareSerial {
+public:
+        SIM800Twilio(
+                uint8_t receive_in, 
+                uint8_t transmit_in, 
+                uint16_t baud_in
+        ) 
+                : SoftwareSerial(receive_in, transmit_in)
+                , receive(receive_in)
+                , transmit(transmit_in)
+                , baud(baud_in)
+        {}
+
+        // Empty destructor
+        ~SIM800Twilio() = default; 
+    
+        // Modem utilities
+        void begin();
+        void reset_modem();
+
+        // Send a machine to machine command
+        bool send_command(String text);
+        
+        // Read a command starting from an index.
+        bool read_command(
+                M2MCommand &m2m, 
+                uint16_t index = 1, 
+                bool delete_non_twilio_msgs = false
+        );
+        
+        // Delete an individual message by index
+        bool delete_SMS(uint16_t);
+    
+private:
+        // Receive pin (software)
+        uint8_t         receive;
+
+        // Transmit pin (software)
+        uint8_t         transmit;
+
+        // Baud rate (software))
+        uint16_t        baud;
+        
+        // Storage for when serial messages come in
+        String          _storage;
+
+        // Utility functions to send/receive SMS and to read strings from
+        // Sim800 serial
+        String          _read_serial(int16_t timeout = READ_SMS_TIMEOUT);
+        String          _read_SMS(uint8_t index);
+        bool            _send_SMS(String number, String message);
+};

--- a/wireless/quickstart/m2m_commands_arduino_sim800/m2m_commands_arduino_sim800.ino
+++ b/wireless/quickstart/m2m_commands_arduino_sim800/m2m_commands_arduino_sim800.ino
@@ -1,95 +1,83 @@
 /*
-    Twilio Machine to Machine Commands Quickstart on Adafruit Feather 32u4 FONA
-*/
-
-#include "Adafruit_FONA.h"
+ * Twilio Machine to Machine Commands Quickstart on Arduino.
+ * 
+ * Uses a SIMCom SIM800. Any ATMega328 board should work, just change the 
+ * pins and wiring.
+ */
 #include <SoftwareSerial.h>
+#include "SIM800Twilio.hpp"
 
-#define FONA_RX  9
-#define FONA_TX  8
-#define FONA_RST 4
-#define FONA_RI  7
+/* 
+ *  Software Serial definitions:
+ *  https://www.arduino.cc/en/Reference/SoftwareSerial
+ *  
+ *  If you get errors, lower the modem baud rate.
+ */
+#define RX_PIN 10
+#define TX_PIN 11 
+#define MODEM_BAUD 4800
 
-/*
-    Software Serial definitions:
-    https://www.arduino.cc/en/Reference/SoftwareSerial
+SIM800Twilio modem(RX_PIN, TX_PIN, MODEM_BAUD);
 
-    If you get errors, lower the modem baud rate.
-*/
-SoftwareSerial fonaSS = SoftwareSerial(FONA_TX, FONA_RX);
-SoftwareSerial *fonaSerial = &fonaSS;
-
-Adafruit_FONA fona = Adafruit_FONA(FONA_RST);
-
-char replybuffer[255];
-
-void setup() {
-  while (!Serial);
-  Serial.begin(115200);
-  Serial.println(F("FONA SMS caller ID test"));
-  Serial.println(F("Initializing....(May take 3 seconds)"));
-
-  /*
-     Adafruit Feather 32u4 FONA setup
-  */
-  fonaSerial->begin(4800);
-  if (! fona.begin(*fonaSerial)) {
-    Serial.println(F("Couldn't find FONA"));
-    while (1);
-  }
-  Serial.println(F("FONA is OK"));
-  fonaSerial->print("AT+CNMI=2,1\r\n");
-
-  Serial.println("Sending Command!");
- 
-  /*
-     Send an SMS to short code 2936, which is a Twilio
-     Machine to machine command.
-  */
-  char sendto[21] = "2936";
-
-  /*
-      Keep `command` under 160 ASCII characters, or 67 UCS-2 characters.
-      https://www.twilio.com/docs/glossary/what-sms-character-limit
-  */
-  char command[141] = "hello from feather32u4";
-
-  /*
-      Write a Twilio M2M command.
-  */
-  if (!fona.sendSMS(sendto, command)) {
-    Serial.println(F("Failed"));
-  } else {
-    Serial.println(F("Sent!"));
-  }
+/* One time setup things - serial, modem */
+void setup() 
+{
+        SerialUSB.begin(115200);
+        SerialUSB.println("Twilio Programmable Wireless SIM800L Demo");
+        modem.begin();
 }
 
-void loop() {
-  uint16_t smslen;
-  int index = 1;
-  /*
-      Read a Twilio M2M command. Note that it will find the lowest
-      indexed one with the code as is; in your code. if you cache the
-      index you can start the next read_command to move to the next one.
-  */
 
-  if (!fona.readSMS(index, replybuffer, 250, &smslen)) {
-    Serial.println(F("Failed!"));
-  } else {
+/* Endless loop. Add your code here to customize this example. */
+void loop() 
+{
+        /* 
+         *  Keep `command` under 160 ASCII characters, or 67 UCS-2 characters.
+         *  https://www.twilio.com/docs/glossary/what-sms-character-limit
+         */
+        String command = "Ahoy, world!";
 
-    /* Print the command */
-    Serial.println(replybuffer);
-    delay(2000);
+        /* 
+         *  Write a Twilio M2M command. 
+         */
+        SerialUSB.print("Sending command: ");
+        SerialUSB.println(command);
+        modem.send_command(command);
 
-    /* Delete the stored command */
-    fona.deleteSMS(1);
+        /* 
+         *  Read a Twilio M2M command. Note that it will find the lowest 
+         *  indexed one with the code as is; in your code. if you cache the 
+         *  index you can start the next read_command to move to the next one.
+         */
+        SerialUSB.println("\r\nLooking for a M2M command...\r\n");
+        M2MCommand m2m;
 
-    /* That's all, folks! */
-    Serial.println("Finished.");
-    while (1) {
-      delay(5000);
-    }
-  }
-  /* Poll for a stored command every 5 seconds */
-  delay(5000);
+        /* Index to start search for M2M command */
+        static uint8_t index = 1; 
+
+        /* Delete any SMS encountered which are not commands? */
+        bool delete_non_commands = false;
+
+        /* If you find a command, print out the index, timestamp, and command. */
+        if (modem.read_command(m2m, index, delete_non_commands)) {
+                SerialUSB.println("----------------------------------------");
+                SerialUSB.print("Index: ");
+                SerialUSB.println(m2m.index);
+
+                SerialUSB.print("Date: ");
+                SerialUSB.println(m2m.date);
+
+                SerialUSB.print("\r\n");
+                SerialUSB.println(m2m.command);
+        } else {
+               SerialUSB.println("Couldn't find a M2M command!"); 
+        }
+
+        /* That's all, folks! */
+        SerialUSB.println("Finished.");
+        while(1) {
+                delay(5000);
+        }
 }
+
+

--- a/wireless/quickstart/m2m_commands_arduino_sim800/meta.json
+++ b/wireless/quickstart/m2m_commands_arduino_sim800/meta.json
@@ -1,5 +1,5 @@
 {
   "type": "server",
-  "title": "Programmable Wireless Machine to Machine commands with an Adafruit Feather 32u4 FONA",
-  "description": "Send and receive machine to machine commands (M2) with an Arduino Nano or Uno and SIM800"
+  "title": "Programmable Wireless Machine to Machine commands with an Arduino Uno or Nano and SIM800 Modem",
+  "description": "Send and receive machine to machine commands (M2M) with an Arduino Nano or Uno and SIM800"
 }

--- a/wireless/quickstart/m2m_commands_feather32u4fona/m2m_commands_feather32u4fona.ino
+++ b/wireless/quickstart/m2m_commands_feather32u4fona/m2m_commands_feather32u4fona.ino
@@ -1,0 +1,95 @@
+/*
+    Twilio Machine to Machine Commands Quickstart on Adafruit Feather 32u4 FONA
+*/
+
+#include "Adafruit_FONA.h"
+#include <SoftwareSerial.h>
+
+#define FONA_RX  9
+#define FONA_TX  8
+#define FONA_RST 4
+#define FONA_RI  7
+
+/*
+    Software Serial definitions:
+    https://www.arduino.cc/en/Reference/SoftwareSerial
+
+    If you get errors, lower the modem baud rate.
+*/
+SoftwareSerial fonaSS = SoftwareSerial(FONA_TX, FONA_RX);
+SoftwareSerial *fonaSerial = &fonaSS;
+
+Adafruit_FONA fona = Adafruit_FONA(FONA_RST);
+
+char replybuffer[255];
+
+void setup() {
+  while (!Serial);
+  Serial.begin(115200);
+  Serial.println(F("FONA SMS caller ID test"));
+  Serial.println(F("Initializing....(May take 3 seconds)"));
+
+  /*
+     Adafruit Feather 32u4 FONA setup
+  */
+  fonaSerial->begin(4800);
+  if (! fona.begin(*fonaSerial)) {
+    Serial.println(F("Couldn't find FONA"));
+    while (1);
+  }
+  Serial.println(F("FONA is OK"));
+  fonaSerial->print("AT+CNMI=2,1\r\n");
+
+  Serial.println("Sending Command!");
+ 
+  /*
+     Send an SMS to short code 2936, which is a Twilio
+     Machine to machine command.
+  */
+  char sendto[21] = "2936";
+
+  /*
+      Keep `command` under 160 ASCII characters, or 67 UCS-2 characters.
+      https://www.twilio.com/docs/glossary/what-sms-character-limit
+  */
+  char command[141] = "hello from feather32u4";
+
+  /*
+      Write a Twilio M2M command.
+  */
+  if (!fona.sendSMS(sendto, command)) {
+    Serial.println(F("Failed"));
+  } else {
+    Serial.println(F("Sent!"));
+  }
+}
+
+void loop() {
+  uint16_t smslen;
+  int index = 1;
+  /*
+      Read a Twilio M2M command. Note that it will find the lowest
+      indexed one with the code as is; in your code. if you cache the
+      index you can start the next read_command to move to the next one.
+  */
+
+  if (!fona.readSMS(index, replybuffer, 250, &smslen)) {
+    Serial.println(F("Failed!"));
+  } else {
+
+    /* Print the command */
+    Serial.println(replybuffer);
+    delay(2000);
+
+    /* Delete the stored command */
+    fona.deleteSMS(1);
+
+    /* That's all, folks! */
+    Serial.println("Finished.");
+    while (1) {
+      delay(5000);
+    }
+  }
+  /* Poll for a stored command every 5 seconds */
+  delay(5000);
+}

--- a/wireless/quickstart/m2m_commands_feather32u4fona/meta.json
+++ b/wireless/quickstart/m2m_commands_feather32u4fona/meta.json
@@ -1,0 +1,5 @@
+{
+  "type": "server",
+  "title": "Programmable Wireless Machine to Machine commands with an Adafruit Feather 32u4 FONA",
+  "description": "Send and receive machine to machine commands (M2M) with an Adafruit Feather 32u4 FONA"
+}


### PR DESCRIPTION
I added a new Quickstart to Wireless:

m2m_commands_feather32u4fona
- This is an example of how to create M2M commands using the Adafruit Feather 32u4 FONA board. The code follows the same paradigm as the Arduino/SIM800 example.

m2m_commands_arduino_sim800
- Added this back since I messed up the CMS yesterday. Good to go.