### PR TITLE
Update snippet to use .enqueue

### DIFF
--- a/rest/taskrouter/twiml/example4/example/example.3.x.js
+++ b/rest/taskrouter/twiml/example4/example/example.3.x.js
@@ -10,7 +10,7 @@ app.post('/enqueue_call', (request, response) => {
   const json = { account_number: '12345abcdef' };
 
   resp
-    .enqueueTask({
+    .enqueue({
       workflowSid: 'WW0123456789abcdef0123456789abcdef',
       waitUrl: '/hold_music.php',
       action: '/post_bridge_survey.php',


### PR DESCRIPTION
Per https://issues.corp.twilio.com/browse/DEVED-3483, enqueueTask() no longer works – the lib now expects .enqueue()