### PR TITLE
Update answer_call.5.x.php

### DIFF
--- a/quickstart/php/voice/answer_call/answer_call.5.x.php
+++ b/quickstart/php/voice/answer_call/answer_call.5.x.php
@@ -3,7 +3,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Twilio\TwiML;
 
 // Start our TwiML response
-$response = new TwiML;
+$response = new TwiML\VoiceResponse();
 
 // Read a message aloud to the caller
 $response->say(


### PR DESCRIPTION
I think there is an error with the code sample, and documentation on the website: https://www.twilio.com/docs/voice/quickstart/php - Receive and Respond to inbound voice calls. I was getting an error saying `Uncaught Error: Class 'Twilio\\TwiML' not found` I believe the Twiml class was deprecated and we should use the `VoiceResponse` class