### PR TITLE
Use status 204 for an emtpy response.

### DIFF
--- a/rest/messages/sms-handle-callback/sms-handle-callback.3.x.js
+++ b/rest/messages/sms-handle-callback/sms-handle-callback.3.x.js
@@ -12,7 +12,7 @@ app.post('/MessageStatus', (req, res) => {
 
   console.log(`SID: ${messageSid}, Status: ${messageStatus}`);
 
-  res.sendStatus(200);
+  res.sendStatus(204);
 });
 
 http.createServer(app).listen(1337, () => {


### PR DESCRIPTION
As in the updated answer to this question: https://stackoverflow.com/questions/49289113/twilio-11200-errors-in-sms-status-callback/49289677#49289677, 204 means OK, but with no body, which is what this endpoing is returning.

There's nothing like being rigorous with HTTP statuses to get your morning started.