### PR TITLE
Updates signatures for validation snippets.

### DIFF
--- a/security/signature_validation/signature_validation.2.x.js
+++ b/security/signature_validation/signature_validation.2.x.js
@@ -17,6 +17,6 @@ const params = {
 };
 
 // The X-Twilio-Signature header attached to the request
-const twilioSignature = 'GvWf1cFY/Q7PnoempGyD5oXAezc=';
+const twilioSignature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ=';
 
 console.log(client.validateRequest(authToken, twilioSignature, url, params));

--- a/security/signature_validation/signature_validation.3.x.js
+++ b/security/signature_validation/signature_validation.3.x.js
@@ -17,6 +17,6 @@ const params = {
 };
 
 // The X-Twilio-Signature header attached to the request
-const twilioSignature = 'GvWf1cFY/Q7PnoempGyD5oXAezc=';
+const twilioSignature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ=';
 
 console.log(client.validateRequest(authToken, twilioSignature, url, params));

--- a/security/signature_validation/signature_validation.4.x.php
+++ b/security/signature_validation/signature_validation.4.x.php
@@ -24,7 +24,7 @@ $postVars = array(
 
 // The X-Twilio-Signature header - in PHP this should be
 // $_SERVER["HTTP_X_TWILIO_SIGNATURE"];
-$signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc=';
+$signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ=';
 
 if ($validator->validate($signature, $url, $postVars)) {
     echo "Confirmed to have come from Twilio.";

--- a/security/signature_validation/signature_validation.4.x.rb
+++ b/security/signature_validation/signature_validation.4.x.rb
@@ -15,6 +15,6 @@ params = {
   'To'      => '+18005551212'
 }
 # The X-Twilio-Signature header attached to the request
-twilio_signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc='
+twilio_signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ='
 
-print(validator.validate(url, params, twilio_signature))
+puts validator.validate(url, params, twilio_signature)

--- a/security/signature_validation/signature_validation.5.x.cs
+++ b/security/signature_validation/signature_validation.5.x.cs
@@ -18,7 +18,7 @@ class Example
         const string url = "https://mycompany.com/myapp.php?foo=1&bar=2";
 
         // The X-Twilio-Signature header attached to the request
-        const string twilioSignature = "GvWf1cFY/Q7PnoempGyD5oXAezc=";
+        const string twilioSignature = "0/KCTR6DLpKmkAf8muzZqo1nDgQ=";
 
         var parameters = new Dictionary<string, string>
         {

--- a/security/signature_validation/signature_validation.5.x.php
+++ b/security/signature_validation/signature_validation.5.x.php
@@ -11,7 +11,7 @@ $token = "12345";
 
 // The X-Twilio-Signature header - in PHP this should be
 // $_SERVER["HTTP_X_TWILIO_SIGNATURE"];
-$signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc=';
+$signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ=';
 
 // Initialize the validator
 $validator = new RequestValidator($token);

--- a/security/signature_validation/signature_validation.5.x.py
+++ b/security/signature_validation/signature_validation.5.x.py
@@ -16,6 +16,6 @@ params = {
 }
 
 # The X-Twilio-Signature header attached to the request
-twilio_signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc='
+twilio_signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ='
 
 print(validator.validate(url, params, twilio_signature))

--- a/security/signature_validation/signature_validation.5.x.rb
+++ b/security/signature_validation/signature_validation.5.x.rb
@@ -15,6 +15,6 @@ params = {
   'To'      => '+18005551212'
 }
 # The X-Twilio-Signature header attached to the request
-twilio_signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc='
+twilio_signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ='
 
-print(validator.validate(url, params, twilio_signature))
+puts validator.validate(url, params, twilio_signature)

--- a/security/signature_validation/signature_validation.6.x.java
+++ b/security/signature_validation/signature_validation.6.x.java
@@ -24,7 +24,7 @@ public class Example {
     params.put("To", "+18005551212");
 
     // The X-Twilio-Signature header attached to the request
-    String twilioSignature = "GvWf1cFY/Q7PnoempGyD5oXAezc=";
+    String twilioSignature = "0/KCTR6DLpKmkAf8muzZqo1nDgQ=";
 
     System.out.println(validator.validateRequest(twilioSignature, url, params));
   }

--- a/security/signature_validation/signature_validation.6.x.py
+++ b/security/signature_validation/signature_validation.6.x.py
@@ -16,6 +16,6 @@ params = {
 }
 
 # The X-Twilio-Signature header attached to the request
-twilio_signature = 'GvWf1cFY/Q7PnoempGyD5oXAezc='
+twilio_signature = '0/KCTR6DLpKmkAf8muzZqo1nDgQ='
 
 print(validator.validate(url, params, twilio_signature))

--- a/security/signature_validation/signature_validation.7.x.java
+++ b/security/signature_validation/signature_validation.7.x.java
@@ -24,7 +24,7 @@ public class Example {
     params.put("To", "+18005551212");
 
     // The X-Twilio-Signature header attached to the request
-    String twilioSignature = "GvWf1cFY/Q7PnoempGyD5oXAezc=";
+    String twilioSignature = "0/KCTR6DLpKmkAf8muzZqo1nDgQ=";
 
     System.out.println(validator.validate(url, params, twilioSignature));
   }


### PR DESCRIPTION
While replacing test numbers, the signatures weren't updated so the validation snippets were all invalid.

Also, Ruby prefers `puts` to `print`.