### PR TITLE
Use `to_jwt` method instead of erroneous `generate` call

### DIFF
--- a/client/capability-token-2way/capability-token.6.x.py
+++ b/client/capability-token-2way/capability-token.6.x.py
@@ -18,7 +18,7 @@ def get_capability_token():
     application_sid = 'APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     capability.allow_client_outgoing(application_sid)
     capability.allow_client_incoming(request.form["ClientName"])
-    token = capability.generate()
+    token = capability.to_jwt()
 
     return Response(token, mimetype='application/jwt')
 

--- a/client/capability-token-outgoing/capability-token.6.x.py
+++ b/client/capability-token-outgoing/capability-token.6.x.py
@@ -17,7 +17,7 @@ def get_capability_token():
     # Twilio Application Sid
     application_sid = 'APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     capability.allow_client_outgoing(application_sid)
-    token = capability.generate()
+    token = capability.to_jwt()
 
     return Response(token, mimetype='application/jwt')
 

--- a/client/capability-token/capability-token.6.x.py
+++ b/client/capability-token/capability-token.6.x.py
@@ -18,7 +18,7 @@ def get_capability_token():
     application_sid = 'APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     capability.allow_client_outgoing(application_sid)
     capability.allow_client_incoming('joey')
-    token = capability.generate()
+    token = capability.to_jwt()
 
     return Response(token, mimetype='application/jwt')
 


### PR DESCRIPTION
`generate` is not a method of ClientCapabilityToken or the base class JWT.