### PR TITLE
Adding snippets for Chat token management

### DIFF
--- a/ip-messaging/tokens/initialization/initialization.java
+++ b/ip-messaging/tokens/initialization/initialization.java
@@ -1,0 +1,14 @@
+import com.twilio.chat.ChatClient;
+import com.twilio.chat.ChatClientListener;
+
+ChatClient.Properties.Builder builder = new ChatClient.Properties.Builder();
+ChatClient.Properties properties = builder.createProperties();
+// See below for event listener implementation
+ChatClientListener listener = new ChatClientListener();
+
+// Make a secure request to your backend to retrieve an access token.
+// Use an authentication mechanism to prevent token exposure to 3rd parties.
+
+String accessToken = "<your token here>";
+
+ChatClient.create(getApplicationContext(), accessToken, properties, listener);

--- a/ip-messaging/tokens/initialization/initialization.java
+++ b/ip-messaging/tokens/initialization/initialization.java
@@ -3,8 +3,8 @@ import com.twilio.chat.ChatClientListener;
 
 ChatClient.Properties.Builder builder = new ChatClient.Properties.Builder();
 ChatClient.Properties properties = builder.createProperties();
-// See below for event listener implementation
-ChatClientListener listener = new ChatClientListener();
+// See below for client event listener implementation
+ChatClientListener listener = new Listener();
 
 // Make a secure request to your backend to retrieve an access token.
 // Use an authentication mechanism to prevent token exposure to 3rd parties.

--- a/ip-messaging/tokens/initialization/initialization.js
+++ b/ip-messaging/tokens/initialization/initialization.js
@@ -1,0 +1,11 @@
+const Chat = require('twilio-chat');
+
+// Make a secure request to your backend to retrieve an access token.
+// Use an authentication mechanism to prevent token exposure to 3rd parties.
+
+const accessToken = '<your accessToken>';
+
+Chat.Client.create(accessToken)
+  .then(client => {
+    // Use Programmable Chat client
+  });

--- a/ip-messaging/tokens/initialization/initialization.m
+++ b/ip-messaging/tokens/initialization/initialization.m
@@ -1,0 +1,13 @@
+#import <TwilioChatClient/TwilioChatClient.h>
+
+// Make a secure request to your backend to retrieve an access token.
+// Use an authentication mechanism to prevent token exposure to 3rd parties.
+
+NSString *accessToken = @"<your token here>";
+
+[TwilioChatClient chatClientWithToken:accessToken
+  properties:properties delegate:delegate completion:(TCHResult *result, TwilioChatClient *client) {
+    if (![result isSuccessful]) {
+      // warn the user the initialization didn't succeed
+    }
+  }];

--- a/ip-messaging/tokens/initialization/initialization.swift
+++ b/ip-messaging/tokens/initialization/initialization.swift
@@ -1,0 +1,14 @@
+import TwilioChatClient
+
+// Make a secure request to your backend to retrieve an access token.
+// Use an authentication mechanism to prevent token exposure to 3rd parties.
+
+let accessToken = "<your token here>"
+
+TwilioChatClient.chatClient(withToken: accessToken,
+  properties: nil, delegate: self) {
+    (result, chatClient) in
+    if (!result.isSuccessful()) {
+      // warn the user the initialization didn't succeed
+    }
+  }

--- a/ip-messaging/tokens/initialization/meta.json
+++ b/ip-messaging/tokens/initialization/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Initializing Chat SDK",
+  "type": "mobile"
+}

--- a/ip-messaging/tokens/renewal/meta.json
+++ b/ip-messaging/tokens/renewal/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Responding to Renewal Events",
+  "type": "mobile"
+}

--- a/ip-messaging/tokens/renewal/renewal.java
+++ b/ip-messaging/tokens/renewal/renewal.java
@@ -1,15 +1,14 @@
 public class Listener implements ChatClientListener {
-
   @Override public void onTokenAboutToExpire()
   {
-    // Make a secure request to your backend to retrieve a refreshed access token.
+    // Implement fetchToken() to make a secure request to your backend to retrieve a refreshed access token.
     // Use an authentication mechanism to prevent token exposure to 3rd parties.
-    String updatedToken = fetchToken();
-
-    chatClient.updateToken(updatedToken, new StatusListener {
-      @Override public void onSuccess() {
-        System.out.println("Token renewed successfully");
-      }
+    fetchToken((String updatedToken) -> {
+      chatClient.updateToken(updatedToken, new StatusListener {
+        @Override public void onSuccess() {
+          System.out.println("Token renewed successfully");
+        }
+      });
     });
   }
 }

--- a/ip-messaging/tokens/renewal/renewal.java
+++ b/ip-messaging/tokens/renewal/renewal.java
@@ -1,6 +1,3 @@
-import com.twilio.chat.ChatClientListener;
-import com.twilio.chat.StatusListener;
-
 public class Listener implements ChatClientListener {
 
   @Override public void onTokenAboutToExpire()

--- a/ip-messaging/tokens/renewal/renewal.java
+++ b/ip-messaging/tokens/renewal/renewal.java
@@ -1,0 +1,18 @@
+import com.twilio.chat.ChatClientListener;
+import com.twilio.chat.StatusListener;
+
+public class Listener implements ChatClientListener {
+
+  @Override public void onTokenAboutToExpire()
+  {
+    // Make a secure request to your backend to retrieve a refreshed access token.
+    // Use an authentication mechanism to prevent token exposure to 3rd parties.
+    String updatedToken = fetchToken();
+
+    chatClient.updateToken(updatedToken, new StatusListener {
+      @Override public void onSuccess() {
+        System.out.println("Token renewed successfully");
+      }
+    });
+  }
+}

--- a/ip-messaging/tokens/renewal/renewal.js
+++ b/ip-messaging/tokens/renewal/renewal.js
@@ -1,7 +1,7 @@
 chatClient.on('tokenAboutToExpire', function() {
-  // Make a secure request to your backend to retrieve a refreshed access token.
+  // Implement fetchToken() to make a secure request to your backend to retrieve a refreshed access token.
   // Use an authentication mechanism to prevent token exposure to 3rd parties.
-  const updatedToken = await fetchToken();
-
-  chatClient.updateToken(updatedToken);
+  fetchToken(function(updatedToken) {
+    chatClient.updateToken(updatedToken);
+  });
 });

--- a/ip-messaging/tokens/renewal/renewal.js
+++ b/ip-messaging/tokens/renewal/renewal.js
@@ -1,0 +1,7 @@
+chatClient.on('tokenAboutToExpire', function() {
+  // Make a secure request to your backend to retrieve a refreshed access token.
+  // Use an authentication mechanism to prevent token exposure to 3rd parties.
+  const updatedToken = await fetchToken();
+
+  chatClient.updateToken(updatedToken);
+});

--- a/ip-messaging/tokens/renewal/renewal.m
+++ b/ip-messaging/tokens/renewal/renewal.m
@@ -1,0 +1,12 @@
+- (void)chatClientTokenWillExpire:(TwilioChatClient *)chatClient {
+    // Make a secure request to your backend to retrieve a refreshed access token.
+    // Use an authentication mechanism to prevent token exposure to 3rd parties.
+    NSString *accessToken = fetchToken();
+
+    [chatClient updateToken:accessToken
+        completion:^(TCHResult * _Nonnull result) {
+            if (!result.isSuccessful) {
+                NSLog(@"Error updating token: %@", result.error);
+            }
+        }];
+}

--- a/ip-messaging/tokens/renewal/renewal.m
+++ b/ip-messaging/tokens/renewal/renewal.m
@@ -1,12 +1,12 @@
 - (void)chatClientTokenWillExpire:(TwilioChatClient *)chatClient {
-    // Make a secure request to your backend to retrieve a refreshed access token.
-    // Use an authentication mechanism to prevent token exposure to 3rd parties.
-    NSString *accessToken = fetchToken();
-
-    [chatClient updateToken:accessToken
-        completion:^(TCHResult * _Nonnull result) {
-            if (!result.isSuccessful) {
-                NSLog(@"Error updating token: %@", result.error);
-            }
-        }];
+  // Implement fetchToken() to make a secure request to your backend to retrieve a refreshed access token.
+  // Use an authentication mechanism to prevent token exposure to 3rd parties.
+  [self fetchToken:completion:^(NSString *updatedToken) {
+    [chatClient updateToken:updatedToken
+      completion:^(TCHResult * _Nonnull result) {
+        if (!result.isSuccessful) {
+          NSLog(@"Error updating token: %@", result.error);
+        }
+      }];
+  }]
 }

--- a/ip-messaging/tokens/renewal/renewal.swift
+++ b/ip-messaging/tokens/renewal/renewal.swift
@@ -1,0 +1,12 @@
+func chatClientTokenWillExpire(_ chatClient: TwilioChatClient) {
+    // Make a secure request to your backend to retrieve a refreshed access token.
+    // Use an authentication mechanism to prevent token exposure to 3rd parties.
+    let accessToken = fetchToken()
+
+    chatClient.updateToken(accessToken, completion: { (result) in
+        if !result.isSuccessful() {
+            print("Error updating token: \(String(describing: result.error?.description))")
+            return
+        }
+    })
+}

--- a/ip-messaging/tokens/renewal/renewal.swift
+++ b/ip-messaging/tokens/renewal/renewal.swift
@@ -1,12 +1,14 @@
 func chatClientTokenWillExpire(_ chatClient: TwilioChatClient) {
-    // Make a secure request to your backend to retrieve a refreshed access token.
-    // Use an authentication mechanism to prevent token exposure to 3rd parties.
-    let accessToken = fetchToken()
-
-    chatClient.updateToken(accessToken, completion: { (result) in
+  // Implement fetchToken() to make a secure request to your backend to retrieve a refreshed access token.
+  // Use an authentication mechanism to prevent token exposure to 3rd parties.
+  fetchToken(completion: { (updatedToken) -> (Void) in
+    if let updatedToken = updatedToken {
+      chatClient.updateToken(updatedToken, completion: { (result) in
         if !result.isSuccessful() {
-            print("Error updating token: \(String(describing: result.error?.description))")
+          print("Error updating token: \(String(describing: result.error?.description))")
             return
-        }
-    })
+          }
+      })
+    }
+  })
 }

--- a/ip-messaging/tokens/update/meta.json
+++ b/ip-messaging/tokens/update/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Updating a Token in Chat SDK",
+  "type": "mobile"
+}

--- a/ip-messaging/tokens/update/update.java
+++ b/ip-messaging/tokens/update/update.java
@@ -1,0 +1,5 @@
+chatClient.updateToken(accessToken, new StatusListener {
+  @Override public void onSuccess() {
+    System.out.println("Token updated successfully");
+  }
+});

--- a/ip-messaging/tokens/update/update.js
+++ b/ip-messaging/tokens/update/update.js
@@ -1,0 +1,1 @@
+chatClient.updateToken(accessToken);

--- a/ip-messaging/tokens/update/update.m
+++ b/ip-messaging/tokens/update/update.m
@@ -1,0 +1,5 @@
+[chatClient updateToken:accessToken completion:^(TCHResult *result) {
+  if (![result isSuccessful]) {
+    // warn the user the update didn't succeed
+  }
+}];

--- a/ip-messaging/tokens/update/update.swift
+++ b/ip-messaging/tokens/update/update.swift
@@ -1,0 +1,5 @@
+chatClient.updateToken(accessToken) { (result) in
+  if (!result.isSuccessful()) {
+    // warn the user the update didn't succeed
+  }
+}


### PR DESCRIPTION
Particularly addressing three scenarios:
- initializing the client with initial token
- updating the token with provided string
- using the built-in token lifecycle events