### PR TITLE
Updated deprecated code in sms Twiml generation

### DIFF
--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.5.x.php
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.5.x.php
@@ -2,8 +2,8 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 
 require_once 'vendor/autoload.php'; // Loads the library
-use Twilio\Twiml;
+use Twilio\Twiml\MessagingResponse;
 
-$response = new Twiml;
+$response = new MessagingResponse();
 $response->message("The Robots are coming! Head for the hills!");
 print $response;


### PR DESCRIPTION
I need to update many more snippets as it seems that `Twilio\Twiml` is deprecated in favour of creating specific handlers. I'm not 100% that this is the new way to use the library but once this is confirmed and merged I can update more snippets.