### PR TITLE
IPM-1898: Change userInfoUpdated to userUpdated

### DIFF
--- a/ip-messaging/reachability-indicator/process-user-updates/process-user-updates.js
+++ b/ip-messaging/reachability-indicator/process-user-updates/process-user-updates.js
@@ -1,7 +1,7 @@
 // function called after client init to set up event handlers
 function registerEventHandlers() {
   // Register UserInfo specific event handler
-  chatClient.on('userInfoUpdated', handleUserUpdate(user));
+  chatClient.on('userUpdated', handleUserUpdate(user));
 }
 
 // function to handle any UserInfo updates


### PR DESCRIPTION
This commit fixes an incorrect event name, changing `userInfoUpdated` to `userUpdated`, as described in the [Chat SDK documentation](https://media.twiliocdn.com/sdk/js/chat/releases/3.2.3/docs/Client.html#event:userUpdated__anchor).