### PR TITLE
Fix sortByPropertyOnly to compare the property

### DIFF
--- a/two-factor-authentication/verify-webhook/verify-webhook.3.x.js
+++ b/two-factor-authentication/verify-webhook/verify-webhook.3.x.js
@@ -50,8 +50,8 @@ function verifyCallback(req, apiKey) {
  * @return {number}
  */
 function sortByPropertyOnly(x, y) {
-  const xx = x.split('=');
-  const yy = y.split('=');
+  const xx = x.split('=')[0];
+  const yy = y.split('=')[0];
 
   if (xx < yy) {
     return -1;


### PR DESCRIPTION
Without the fix the comparator function is comparing the full array not only the key of the property.
### Issue:
```javascript
// x = 'property=value';
const xx = x.split('=');
// xx will be an Array['property', 'value']
```
### Fix:
```javascript
// x = 'property=value';
const xx = x.split('=')[0]; // 'property'
// xx will be the first element of the array
```
