### PR TITLE
The Twiml class is deprecated.

### DIFF
--- a/quickstart/php/sms/reply_sms_without_composer/reply_sms.5.x.php
+++ b/quickstart/php/sms/reply_sms_without_composer/reply_sms.5.x.php
@@ -1,10 +1,10 @@
 <?php
 // Include the bundled autoload from the Twilio PHP Helper Library
 require __DIR__ . '/twilio-php-master/src/Twilio/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\MessagingResponse;
 // Set the content-type to XML to send back TwiML from the PHP Helper Library
 header("content-type: text/xml");
-$response = new TwiML();
+$response = new MessagingResponse();
 $response->message(
     "I'm using the Twilio PHP library to respond to this SMS!"
 );


### PR DESCRIPTION
As per https://github.com/twilio/twilio-php/issues/513#issuecomment-438929412, "the correct TwiML code is to use the namespace Twilio\TwiML with a VoiceResponse or MessagingResponse class."