### PR TITLE
Use proper response type

### DIFF
--- a/client/response-twiml-client/response-twiml-client.5.x.php
+++ b/client/response-twiml-client/response-twiml-client.5.x.php
@@ -3,9 +3,9 @@
 
 // this line loads the library 
 require('vendor/autoload.php'); 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
-$response = new TwiML;
+$response = new VoiceResponse;
 
 // get the phone number from the page request parameters, if given
 if (isset($_REQUEST['To'])) {

--- a/client/response-twiml-dial/response-twiml-dial.5.x.php
+++ b/client/response-twiml-dial/response-twiml-dial.5.x.php
@@ -3,9 +3,9 @@
 
 // this line loads the library 
 require('vendor/autoload.php'); 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
-$response = new TwiML;
+$response = new VoiceResponse;
 
 // get the phone number from the page request parameters, if given
 if (isset($_REQUEST['To'])) {

--- a/client/response-twiml/response-twiml.5.x.php
+++ b/client/response-twiml/response-twiml.5.x.php
@@ -3,8 +3,8 @@
 
 // this line loads the library 
 require('vendor/autoload.php'); 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
-$response = new TwiML;
+$response = new VoiceResponse;
 $response->say("Thanks for calling!");
 echo $response;

--- a/guides/request-validation-php-lumen/example-2/example-2.5.x.php
+++ b/guides/request-validation-php-lumen/example-2/example-2.5.x.php
@@ -1,14 +1,14 @@
 <?php
 
 use Illuminate\Http\Request;
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Note: $app was changed for $router since Lumen 5.5.0
 // Reference: https://lumen.laravel.com/docs/5.5/upgrade#upgrade-5.5.0
 
 $router->post('voice', ['middleware' => 'TwilioRequestValidator',
   function() {
-    $twiml = new TwiML();
+    $twiml = new VoiceResponse();
     $twiml->say('Hello World!');
 
     return response($twiml)->header('Content-Type', 'text/xml');
@@ -19,7 +19,7 @@ $router->post('message', ['middleware' => 'TwilioRequestValidator',
   function(Request $request) {
     $bodyLength = strlen($request->input('Body'));
 
-    $twiml = new TwiML();
+    $twiml = new VoiceResponse();
     $twiml->message("Your text to me was $bodyLength characters long. ".
                     "Webhooks are neat :)");
 

--- a/guides/voice/conference-calls-guide/moderated-conference/moderated-conference.php
+++ b/guides/voice/conference-calls-guide/moderated-conference/moderated-conference.php
@@ -3,12 +3,12 @@
 
 // this line loads the library 
 require_once '/path/to/vendor/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Update with your own phone number in E.164 format
 $MODERATOR = '+15558675310';
 
-$response = new TwiML;
+$response = new VoiceResponse;
 
 // Start with a <Dial> verb
 $dial = $response->dial();

--- a/guides/voice/gather-dtmf-tones-guide/gather-example-step-0/example.5.x.php
+++ b/guides/voice/gather-dtmf-tones-guide/gather-example-step-0/example.5.x.php
@@ -3,10 +3,10 @@
 // HTTP POST to /voice in our application
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Use the Twilio PHP SDK to build an XML response
-$response = new TwiML();
+$response = new VoiceResponse();
 
 // Use the <Gather> verb to collect user input
 $gather = $response->gather(array('numDigits' => 1));

--- a/guides/voice/gather-dtmf-tones-guide/gather-example-step-1/example.5.x.php
+++ b/guides/voice/gather-dtmf-tones-guide/gather-example-step-1/example.5.x.php
@@ -3,10 +3,10 @@
 // HTTP POST to /voice in our application
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Use the Twilio PHP SDK to build an XML response
-$response = new TwiML();
+$response = new VoiceResponse();
 
 // If the user entered digits, process their request
 if (array_key_exists('Digits', $_POST)) {

--- a/guides/voice/gather-dtmf-tones-guide/gather-example-step-2.1/example.5.x.php
+++ b/guides/voice/gather-dtmf-tones-guide/gather-example-step-2.1/example.5.x.php
@@ -3,10 +3,10 @@
 // sent as an HTTP POST to /gather in our application
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Use the Twilio PHP SDK to build an XML response
-$response = new TwiML();
+$response = new VoiceResponse();
 
 // If the user entered digits, process their request
 if (array_key_exists('Digits', $_POST)) {

--- a/guides/voice/gather-dtmf-tones-guide/gather-example-step-2/example.5.x.php
+++ b/guides/voice/gather-dtmf-tones-guide/gather-example-step-2/example.5.x.php
@@ -3,10 +3,10 @@
 // HTTP POST to /voice in our application
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Use the Twilio PHP SDK to build an XML response
-$response = new TwiML();
+$response = new VoiceResponse();
 
 // Use the <Gather> verb to collect user input
 $gather = $response->gather(array('numDigits' => 1, 'action' => '/gather'));

--- a/guides/voice/record-calls-guide/record-twiml-transcribe/example.php
+++ b/guides/voice/record-calls-guide/record-twiml-transcribe/example.php
@@ -4,7 +4,7 @@ require_once '/path/to/vendor/autoload.php'; // Loads the library
 
 
 # Start our TwiML response
-$response = new Twilio\TwiML();
+$response = new Twilio\TwiML\VoiceResponse();
 
 # Use <Say> to give the caller some instructions
 $response->say('Hello. Please leave a message and I will transcribe it.');

--- a/guides/voice/record-calls-guide/record-twiml/example.php
+++ b/guides/voice/record-calls-guide/record-twiml/example.php
@@ -4,7 +4,7 @@ require_once '/path/to/vendor/autoload.php'; // Loads the library
 
 
 # Start our TwiML response
-$response = new Twilio\TwiML();
+$response = new Twilio\TwiML\VoiceResponse();
 
 # Use <Say> to give the caller some instructions
 $response->say('Hello. Please leave a message after the beep.');

--- a/guides/voice/recording-add-on-guide/use-add-on-data/example.5.x.php
+++ b/guides/voice/recording-add-on-guide/use-add-on-data/example.5.x.php
@@ -3,12 +3,12 @@ require 'vendor/autoload.php';
 
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 $app = new \Slim\App;
 
 $app->post('/voice', function (Request $request, Response $response) {
-    $twiml = new TwiML;
+    $twiml = new VoiceResponse;
     $twiml->say('Hi! I want to know what do you think about coding.');
     $twiml->record(['maxLength' => 10, 'action' => '/recording']);
     $twiml->hangup();
@@ -18,7 +18,7 @@ $app->post('/voice', function (Request $request, Response $response) {
 });
 
 $app->post('/recording', function (Request $request, Response $response) {
-    $twiml = new TwiML;
+    $twiml = new VoiceResponse;
     $body = $request->getParsedBody();
     $recordingUrl = $body['RecordingUrl'];
 

--- a/guides/voice/respond-incoming-calls-guide/respond-no-parameters/example.5.x.php
+++ b/guides/voice/respond-incoming-calls-guide/respond-no-parameters/example.5.x.php
@@ -3,8 +3,8 @@
 
 // this line loads the library 
 require_once '/path/to/vendor/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
-$response = new TwiML;
+$response = new VoiceResponse;
 $response->say("hello world!", array('voice' => 'alice'));
 print $response;

--- a/guides/voice/respond-incoming-calls-guide/respond-with-parameters/example.5.x.php
+++ b/guides/voice/respond-incoming-calls-guide/respond-with-parameters/example.5.x.php
@@ -1,10 +1,10 @@
 <?php
 require_once './vendor/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 $city = $_REQUEST['FromCity'] ?? 'Guayaquil';
 
-$response = new TwiML();
+$response = new VoiceResponse();
 $response->say("Never gonna give you up, {$city}!", array('voice' => 'alice'));
 $response->play("https://demo.twilio.com/docs/classic.mp3");
 

--- a/quickstart/php/sms/example-3/sms-hello-monkey.5.x.php
+++ b/quickstart/php/sms/example-3/sms-hello-monkey.5.x.php
@@ -2,9 +2,9 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML;
+use Twilio\TwiML\MessagingResponse;
 
-$response = new TwiML();
+$response = new MessagingResponse();
 $response->message('Hello, Mobile Monkey');
 
 header("content-type: text/xml");

--- a/quickstart/php/sms/example-4/mms-hello-monkey.5.x.php
+++ b/quickstart/php/sms/example-4/mms-hello-monkey.5.x.php
@@ -2,9 +2,9 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML\VoiceResponse;
+use Twilio\TwiML\MessagingResponse;
 
-$response = new VoiceResponse();
+$response = new MessagingResponse();
 $message = $response->message();
 $message->body('Hello, Mobile Monkey');
 $message->media('https://demo.twilio.com/owl.png');

--- a/quickstart/php/sms/example-4/mms-hello-monkey.5.x.php
+++ b/quickstart/php/sms/example-4/mms-hello-monkey.5.x.php
@@ -2,9 +2,9 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
-$response = new TwiML();
+$response = new VoiceResponse();
 $message = $response->message();
 $message->body('Hello, Mobile Monkey');
 $message->media('https://demo.twilio.com/owl.png');

--- a/quickstart/php/sms/example-5/reply-by-name.5.x.php
+++ b/quickstart/php/sms/example-5/reply-by-name.5.x.php
@@ -2,7 +2,7 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML;
+use Twilio\TwiML\MessagingResponse;
 
 // make an associative array of senders we know, indexed by phone number
 $people = array(
@@ -15,7 +15,7 @@ $people = array(
 // otherwise, consider them just another monkey
 $name = $people[$_REQUEST['From']] ?: 'Monkey';
 
-$response = new TwiML();
+$response = new MessagingResponse();
 $response->message("{$name}, thanks for the message!");
 
 header("content-type: text/xml");

--- a/quickstart/php/sms/example-6/tracking-sms-conversations.5.x.php
+++ b/quickstart/php/sms/example-6/tracking-sms-conversations.5.x.php
@@ -2,7 +2,7 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML;
+use Twilio\TwiML\MessagingResponse;
 
 // start the session
 session_start();
@@ -28,7 +28,7 @@ $people = array(
 // otherwise, consider them just another monkey
 $name = $people[$_REQUEST['From']] ?: 'Monkey';
 
-$response = new TwiML();
+$response = new MessagingResponse();
 $response->message("{$name} has messaged {$_REQUEST['To']} {$counter} times");
 
 header("content-type: text/xml");

--- a/quickstart/php/sms/example-7/send-sms-during-call.5.x.php
+++ b/quickstart/php/sms/example-7/send-sms-during-call.5.x.php
@@ -2,7 +2,7 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 // following the instructions to install it with Composer.
 require_once "vendor/autoload.php";
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // make an associative array of callers we know, indexed by phone number
 $people = array(
@@ -15,7 +15,7 @@ $people = array(
 // otherwise, consider them just another monkey
 $name = $people[$_REQUEST['From']] ?: 'Monkey';
 
-$response = new TwiML();
+$response = new VoiceResponse();
 $response->say("Hello {$name}");
 $response->message("{$name}, thanks for the call!");
 

--- a/quickstart/php/voice/answer_call/answer_call.5.x.php
+++ b/quickstart/php/voice/answer_call/answer_call.5.x.php
@@ -1,9 +1,9 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Start our TwiML response
-$response = new TwiML;
+$response = new VoiceResponse;
 
 // Read a message aloud to the caller
 $response->say(

--- a/quickstart/php/voice/answer_call_without_composer/answer_call.5.x.php
+++ b/quickstart/php/voice/answer_call_without_composer/answer_call.5.x.php
@@ -1,10 +1,10 @@
 <?php
 // Include the bundled autoload from the Twilio PHP Helper Library
 require __DIR__ . '/twilio-php-master/src/Twilio/autoload.php';
-use Twilio\TwiML;
+use Twilio\TwiML\VoiceResponse;
 
 // Start our TwiML response
-$response = new TwiML;
+$response = new VoiceResponse;
 
 // Read a message aloud to the caller
 $response->say(

--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.5.x.php
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.5.x.php
@@ -2,9 +2,9 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 
 require_once 'vendor/autoload.php'; // Loads the library
-use Twilio\Twiml;
+use Twilio\Twiml\MessagingResponse;
 
-$response = new Twiml;
+$response = new MessagingResponse;
 $body = $_REQUEST['Body'];
 $default = "I just wanna tell you how I'm feeling - Gotta make you understand";
 $options = [

--- a/rest/messages/generate-twiml-mms/generate-twiml-mms.5.x.php
+++ b/rest/messages/generate-twiml-mms/generate-twiml-mms.5.x.php
@@ -2,9 +2,9 @@
 // Get the PHP helper library from https://twilio.com/docs/libraries/php
 
 require_once 'vendor/autoload.php'; // Loads the library
-use Twilio\Twiml;
+use Twilio\Twiml\MessagingResponse;
 
-$response = new Twiml;
+$response = new MessagingResponse;
 $message = $response->message();
 $message->body("The Robots are coming! Head for the hills!");
 $message->media("https://farm8.staticflickr.com/7090/6941316406_80b4d6d50e_z_d.jpg");

--- a/rest/messages/generate-twiml-sms-voice/example-1.5.x.php
+++ b/rest/messages/generate-twiml-sms-voice/example-1.5.x.php
@@ -3,9 +3,9 @@
 
 // this line loads the library 
 require('vendor/autoload.php'); 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml;
+$response = new VoiceResponse;
 $response->say("Hello! You will get an SMS message soon.");
 $response->sms("This is the ship that made the Kessel Run in fourteen parsecs?");
 print $response;

--- a/rest/taskrouter/twiml/example1/example/example.5.x.php
+++ b/rest/taskrouter/twiml/example1/example/example.5.x.php
@@ -2,9 +2,9 @@
 // Download the library and copy into the folder containing this file.
 require_once '/path/to/vendor/autoload.php'; // Loads the library
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->enqueue(array('workflowSid' => 'WW0123456789abcdef0123456789abcdef'));
 print $response;
 ?>

--- a/rest/taskrouter/twiml/example2/example/example.5.x.php
+++ b/rest/taskrouter/twiml/example2/example/example.5.x.php
@@ -2,9 +2,9 @@
 // Download the library and copy into the folder containing this file.
 require_once '/path/to/vendor/autoload.php'; // Loads the library
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->enqueue(["workflowSid" => "WW0123456789abcdef0123456789abcdef"])
     ->task("{'account_number':'12345abcdef'}");
 print $response;

--- a/rest/taskrouter/twiml/example3/example/example.5.x.php
+++ b/rest/taskrouter/twiml/example3/example/example.5.x.php
@@ -2,9 +2,9 @@
 // Download the library and copy into the folder containing this file.
 require_once '/path/to/vendor/autoload.php'; // Loads the library
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->enqueue(array('workflowSid' => 'WW0123456789abcdef0123456789abcdef'))
     ->task(
         "{'account_number':'12345abcdef'}",

--- a/rest/taskrouter/twiml/example4/example/example.5.x.php
+++ b/rest/taskrouter/twiml/example4/example/example.5.x.php
@@ -2,9 +2,9 @@
 // Download the library and copy into the folder containing this file.
 require_once '/path/to/vendor/autoload.php'; // Loads the library
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->enqueue(
     array(
         'workflowSid' => 'WW0123456789abcdef0123456789abcdef',

--- a/voice/queueing/agent/queue-agent.5.x.php
+++ b/voice/queueing/agent/queue-agent.5.x.php
@@ -4,9 +4,9 @@
 // https://www.twilio.com/docs/libraries/php
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->dial()
     ->queue('Queue Demo');
 

--- a/voice/queueing/caller/queue-caller.5.x.php
+++ b/voice/queueing/caller/queue-caller.5.x.php
@@ -4,9 +4,9 @@
 // https://www.twilio.com/docs/libraries/php
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 $response->enqueue('Queue Demo');
 
 echo $response;

--- a/voice/queueing/redirect/queue-redirect.5.x.php
+++ b/voice/queueing/redirect/queue-redirect.5.x.php
@@ -4,9 +4,9 @@
 // https://www.twilio.com/docs/libraries/php
 require_once '/path/to/vendor/autoload.php';
 
-use Twilio\Twiml;
+use Twilio\Twiml\VoiceResponse;
 
-$response = new Twiml();
+$response = new VoiceResponse();
 
 $response->say("You will now be connected to the first caller in the queue.");
 $dial = $response->dial();


### PR DESCRIPTION
Updates older `new Twilio\Twiml()` calls to use `new Twilio\Twiml\VoiceResponse()` and `new Twilio\Twiml\MessagingResponse()`