### PR TITLE
fix: correct the Ruby client capability token examples

### DIFF
--- a/client/capability-token-2way/capability-token.5.x.rb
+++ b/client/capability-token-2way/capability-token.5.x.rb
@@ -4,13 +4,13 @@ require 'sinatra'
 get '/token' do
   account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
   auth_token = 'your_auth_token'
-  capability = Twilio::JWT::Capability.new(account_sid, auth_token)
+  capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token)
 
   # Create an application sid at
   # twilio.com/console/phone-numbers/dev-tools/twiml-apps and use it here
-  capability.allow_client_outgoing('APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
-  capability.allow_client_incoming(params['ClientName'])
-  token = capability.generate
+  capability.add_scope(Twilio::JWT::ClientCapability::OutgoingClientScope.new('APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'))
+  capability.add_scope(Twilio::JWT::ClientCapability::IncomingClientScope.new(params['ClientName']))
+  token = capability.to_jwt
 
   content_type 'application/jwt'
   token

--- a/client/capability-token-expires/capability-token-expires.5.x.rb
+++ b/client/capability-token-expires/capability-token-expires.5.x.rb
@@ -1,3 +1,4 @@
-token = capability.generate expires: 600
+capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token, ttl: 600)
+token = capability.to_jwt
 
 puts token

--- a/client/capability-token-incoming/capability-token.5.x.rb
+++ b/client/capability-token-incoming/capability-token.5.x.rb
@@ -4,10 +4,10 @@ require 'sinatra'
 get '/token' do
   account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
   auth_token = 'your_auth_token'
-  capability = Twilio::JWT::Capability.new(account_sid, auth_token)
+  capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token)
 
-  capability.allow_client_incoming('joey')
-  token = capability.generate
+  capability.add_scope(Twilio::JWT::ClientCapability::IncomingClientScope.new('joey'))
+  token = capability.to_jwt
 
   content_type 'application/jwt'
   token

--- a/client/capability-token-outgoing/capability-token.5.x.rb
+++ b/client/capability-token-outgoing/capability-token.5.x.rb
@@ -4,12 +4,12 @@ require 'sinatra'
 get '/token' do
   account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
   auth_token = 'your_auth_token'
-  capability = Twilio::JWT::Capability.new(account_sid, auth_token)
+  capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token)
 
   # Create an application sid at
   # twilio.com/console/phone-numbers/dev-tools/twiml-apps and use it here
-  capability.allow_client_outgoing('APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
-  token = capability.generate
+  capability.add_scope(Twilio::JWT::ClientCapability::OutgoingClientScope.new('APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'))
+  token = capability.to_jwt
 
   content_type 'application/jwt'
   token

--- a/client/capability-token/capability-token.5.x.rb
+++ b/client/capability-token/capability-token.5.x.rb
@@ -4,13 +4,13 @@ require 'sinatra'
 get '/token' do
   account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
   auth_token = 'your_auth_token'
-  capability = Twilio::JWT::Capability.new(account_sid, auth_token)
+  capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token)
 
   # Create an application sid at
   # twilio.com/console/phone-numbers/dev-tools/twiml-apps and use it here
   capability.allow_client_outgoing('APXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
-  capability.allow_client_incoming('joey')
-  token = capability.generate
+  capability.add_scope(Twilio::JWT::ClientCapability::IncomingClientScope.new('joey'))
+  token = capability.to_jwt
 
   content_type 'application/jwt'
   token


### PR DESCRIPTION
Relates to https://github.com/twilio/twilio-ruby/issues/501