### PR TITLE
fix: correct the Node AccessToken examples to be more compatible with TypeScript

### DIFF
--- a/ip-messaging/users/token-generation-server/token-generation-server.3.x.js
+++ b/ip-messaging/users/token-generation-server/token-generation-server.3.x.js
@@ -33,10 +33,10 @@ app.get('/token', (request, response) => {
   const token = new AccessToken(
     process.env.TWILIO_ACCOUNT_SID,
     process.env.TWILIO_API_KEY,
-    process.env.TWILIO_API_SECRET
+    process.env.TWILIO_API_SECRET,
+    {identity: identity}
   );
   token.addGrant(chatGrant);
-  token.identity = identity;
 
   // Serialize the token to a JWT string and include it in a JSON response
   response.send({

--- a/rest/access-tokens/ip-messaging-example/ip-messaging-example.3.x.js
+++ b/rest/access-tokens/ip-messaging-example/ip-messaging-example.3.x.js
@@ -18,11 +18,14 @@ const chatGrant = new ChatGrant({
 
 // Create an access token which we will sign and return to the client,
 // containing the grant we just created
-const token = new AccessToken(twilioAccountSid, twilioApiKey, twilioApiSecret);
+const token = new AccessToken(
+  twilioAccountSid,
+  twilioApiKey,
+  twilioApiSecret,
+  {identity: identity}
+);
 
 token.addGrant(chatGrant);
-
-token.identity = identity;
 
 // Serialize the token to a JWT string
 console.log(token.toJwt());

--- a/rest/access-tokens/video-example/video-example.3.x.js
+++ b/rest/access-tokens/video-example/video-example.3.x.js
@@ -15,9 +15,13 @@ const videoGrant = new VideoGrant({
 
 // Create an access token which we will sign and return to the client,
 // containing the grant we just created
-const token = new AccessToken(twilioAccountSid, twilioApiKey, twilioApiSecret);
+const token = new AccessToken(
+  twilioAccountSid,
+  twilioApiKey,
+  twilioApiSecret,
+  {identity: identity}
+);
 token.addGrant(videoGrant);
-token.identity = identity;
 
 // Serialize the token to a JWT string
 console.log(token.toJwt());

--- a/rest/access-tokens/voice-example/voice-example.3.x.js
+++ b/rest/access-tokens/voice-example/voice-example.3.x.js
@@ -18,9 +18,13 @@ const voiceGrant = new VoiceGrant({
 
 // Create an access token which we will sign and return to the client,
 // containing the grant we just created
-const token = new AccessToken(twilioAccountSid, twilioApiKey, twilioApiSecret);
+const token = new AccessToken(
+  twilioAccountSid,
+  twilioApiKey,
+  twilioApiSecret,
+  {identity: identity}
+);
 token.addGrant(voiceGrant);
-token.identity = identity;
 
 // Serialize the token to a JWT string
 console.log(token.toJwt());

--- a/video/users/token-generation-server-rooms/token-generation-server.3.x.js
+++ b/video/users/token-generation-server-rooms/token-generation-server.3.x.js
@@ -20,11 +20,9 @@ app.get('/token', (request, response) => {
   const token = new AccessToken(
     process.env.TWILIO_ACCOUNT_SID,
     process.env.TWILIO_API_KEY,
-    process.env.TWILIO_API_SECRET
+    process.env.TWILIO_API_SECRET,
+    {identity: identity}
   );
-
-  // Assign the generated identity to the token.
-  token.identity = identity;
 
   // Grant the access token Twilio Video capabilities.
   const grant = new VideoGrant();

--- a/video/users/token-generation-server/token-generation-server.3.x.js
+++ b/video/users/token-generation-server/token-generation-server.3.x.js
@@ -20,11 +20,9 @@ app.get('/token', (request, response) => {
   const token = new AccessToken(
     process.env.TWILIO_ACCOUNT_SID,
     process.env.TWILIO_API_KEY,
-    process.env.TWILIO_API_SECRET
+    process.env.TWILIO_API_SECRET,
+    {identity: identity}
   );
-
-  // Assign the generated identity to the token.
-  token.identity = identity;
 
   // Grant access to Video.
   const grant = new VideoGrant();


### PR DESCRIPTION
Fixes https://github.com/twilio/twilio-node/issues/579

The `identity` property is not accessible via the TS definition but can be set using the constructor (along with `ttl` and `nbf`).