### PR TITLE
Add dot-env config requirement

### DIFF
--- a/security/signature_validation_tests/signature_validation_tests.3.x.js
+++ b/security/signature_validation_tests/signature_validation_tests.3.x.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 // Get twilio-node from twilio.com/docs/libraries/node
 const webhooks = require('twilio/lib/webhooks/webhooks');
 const request = require('request');


### PR DESCRIPTION
This allows the code to be useable as a snippet alone. Seeing as we're absorbing environment variables and other Twilio documentation suggests including this in .env file, rather than just exporting to the environment; this seems like a sensible change.