### PR TITLE
Fix referSip code samples.

### DIFF
--- a/twiml/voice/refer/refer-1/refer-1.3.x.js
+++ b/twiml/voice/refer/refer-1/refer-1.3.x.js
@@ -2,6 +2,6 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 
 const response = new VoiceResponse();
 const refer = response.refer();
-refer.referSip('sip:alice@example.com');
+refer.sip('sip:alice@example.com');
 
 console.log(response.toString());

--- a/twiml/voice/refer/refer-1/refer-1.5.x.cs
+++ b/twiml/voice/refer/refer-1/refer-1.5.x.cs
@@ -2,13 +2,14 @@ using System;
 using Twilio.TwiML;
 using Twilio.TwiML.Voice;
 
+
 class Example
 {
     static void Main()
     {
         var response = new VoiceResponse();
         var refer = new Refer();
-        refer.ReferSip("sip:alice@example.com");
+        refer.Sip(new Uri("sip:alice@example.com"));
         response.Append(refer);
 
         Console.WriteLine(response.ToString());

--- a/twiml/voice/refer/refer-1/refer-1.6.x.py
+++ b/twiml/voice/refer/refer-1/refer-1.6.x.py
@@ -1,4 +1,4 @@
-from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
+from twilio.twiml.voice_response import Refer, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()

--- a/twiml/voice/refer/refer-1/refer-1.6.x.py
+++ b/twiml/voice/refer/refer-1/refer-1.6.x.py
@@ -1,8 +1,8 @@
-from twilio.twiml.voice_response import Refer, VoiceResponse
+from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()
-refer.refer_sip('sip:alice@example.com')
+refer.sip('sip:alice@example.com')
 response.append(refer)
 
 print(response)

--- a/twiml/voice/refer/refer-1/refer-1.7.x.java
+++ b/twiml/voice/refer/refer-1/refer-1.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 public class Example {
     public static void main(String[] args) {
         ReferSip sip = new ReferSip.Builder("sip:alice@example.com").build();
-        Refer refer = new Refer.Builder().referSip(number).build();
+        Refer refer = new Refer.Builder().sip(sip).build();
         VoiceResponse response = new VoiceResponse.Builder().refer(refer).build();
 
         try {

--- a/twiml/voice/refer/refer-2/refer-2.3.x.js
+++ b/twiml/voice/refer/refer-2/refer-2.3.x.js
@@ -2,6 +2,6 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 
 const response = new VoiceResponse();
 const refer = response.refer();
-refer.referSip('sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question');
+refer.sip('sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question');
 
 console.log(response.toString());

--- a/twiml/voice/refer/refer-2/refer-2.5.x.cs
+++ b/twiml/voice/refer/refer-2/refer-2.5.x.cs
@@ -2,13 +2,14 @@ using System;
 using Twilio.TwiML;
 using Twilio.TwiML.Voice;
 
+
 class Example
 {
     static void Main()
     {
         var response = new VoiceResponse();
         var refer = new Refer();
-        refer.ReferSip("sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question");
+        refer.Sip(new Uri("sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question"));
         response.Append(refer);
 
         Console.WriteLine(response.ToString());

--- a/twiml/voice/refer/refer-2/refer-2.6.x.py
+++ b/twiml/voice/refer/refer-2/refer-2.6.x.py
@@ -1,4 +1,4 @@
-from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
+from twilio.twiml.voice_response import Refer, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()

--- a/twiml/voice/refer/refer-2/refer-2.6.x.py
+++ b/twiml/voice/refer/refer-2/refer-2.6.x.py
@@ -1,8 +1,10 @@
-from twilio.twiml.voice_response import Refer, VoiceResponse
+from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()
-refer.refer_sip('sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question')
+refer.sip(
+    'sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question'
+)
 response.append(refer)
 
 print(response)

--- a/twiml/voice/refer/refer-2/refer-2.7.x.java
+++ b/twiml/voice/refer/refer-2/refer-2.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 public class Example {
     public static void main(String[] args) {
         ReferSip sip = new ReferSip.Builder("sip:alice@example.com?X-AcctNumber=123456&X-ReasonForCalling=billing-question").build();
-        Refer refer = new Refer.Builder().referSip(number).build();
+        Refer refer = new Refer.Builder().sip(sip).build();
         VoiceResponse response = new VoiceResponse.Builder().refer(refer).build();
 
         try {

--- a/twiml/voice/refer/refer-3/refer-3.3.x.js
+++ b/twiml/voice/refer/refer-3/refer-3.3.x.js
@@ -2,6 +2,6 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 
 const response = new VoiceResponse();
 const refer = response.refer();
-refer.referSip('sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex');
+refer.sip('sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex');
 
 console.log(response.toString());

--- a/twiml/voice/refer/refer-3/refer-3.5.x.cs
+++ b/twiml/voice/refer/refer-3/refer-3.5.x.cs
@@ -2,13 +2,14 @@ using System;
 using Twilio.TwiML;
 using Twilio.TwiML.Voice;
 
+
 class Example
 {
     static void Main()
     {
         var response = new VoiceResponse();
         var refer = new Refer();
-        refer.ReferSip("sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex");
+        refer.Sip(new Uri("sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex"));
         response.Append(refer);
 
         Console.WriteLine(response.ToString());

--- a/twiml/voice/refer/refer-3/refer-3.6.x.py
+++ b/twiml/voice/refer/refer-3/refer-3.6.x.py
@@ -1,4 +1,4 @@
-from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
+from twilio.twiml.voice_response import Refer, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()

--- a/twiml/voice/refer/refer-3/refer-3.6.x.py
+++ b/twiml/voice/refer/refer-3/refer-3.6.x.py
@@ -1,8 +1,8 @@
-from twilio.twiml.voice_response import Refer, VoiceResponse
+from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer()
-refer.refer_sip('sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex')
+refer.sip('sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex')
 response.append(refer)
 
 print(response)

--- a/twiml/voice/refer/refer-3/refer-3.7.x.java
+++ b/twiml/voice/refer/refer-3/refer-3.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.twiml.TwiMLException;
 public class Example {
     public static void main(String[] args) {
         ReferSip sip = new ReferSip.Builder("sip:alice@example.com?User-to-User=123456789%3Bencoding%3Dhex").build();
-        Refer refer = new Refer.Builder().referSip(number).build();
+        Refer refer = new Refer.Builder().sip(sip).build();
         VoiceResponse response = new VoiceResponse.Builder().refer(refer).build();
 
         try {

--- a/twiml/voice/refer/refer-4/refer-4.3.x.js
+++ b/twiml/voice/refer/refer-4/refer-4.3.x.js
@@ -2,9 +2,9 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 
 const response = new VoiceResponse();
 const refer = response.refer({
-    'action': '/handleRefer',
-    'method': 'POST'
+    action: '/handleRefer',
+    method: 'POST'
 });
-refer.referSip('sip:alice@example.com');
+refer.sip('sip:alice@example.com');
 
 console.log(response.toString());

--- a/twiml/voice/refer/refer-4/refer-4.5.x.cs
+++ b/twiml/voice/refer/refer-4/refer-4.5.x.cs
@@ -2,14 +2,14 @@ using System;
 using Twilio.TwiML;
 using Twilio.TwiML.Voice;
 
+
 class Example
 {
     static void Main()
     {
         var response = new VoiceResponse();
-        var refer = new Refer(action: new Uri("/handleRefer"),
-            method: Twilio.Http.HttpMethod.Post);
-        refer.ReferSip("sip:alice@example.com");
+        var refer = new Refer(action: new Uri("/handleRefer"), method: Twilio.Http.HttpMethod.Post);
+        refer.Sip(new Uri("sip:alice@example.com"));
         response.Append(refer);
 
         Console.WriteLine(response.ToString());

--- a/twiml/voice/refer/refer-4/refer-4.5.x.php
+++ b/twiml/voice/refer/refer-4/refer-4.5.x.php
@@ -3,8 +3,7 @@ require_once './vendor/autoload.php';
 use Twilio\TwiML\VoiceResponse;
 
 $response = new VoiceResponse();
-$refer = $response->refer(['action' => '/handleRefer',
-    'method' => 'POST']);
+$refer = $response->refer(['action' => '/handleRefer', 'method' => 'POST']);
 $refer->sip('sip:alice@example.com');
 
 echo $response;

--- a/twiml/voice/refer/refer-4/refer-4.6.x.py
+++ b/twiml/voice/refer/refer-4/refer-4.6.x.py
@@ -1,4 +1,4 @@
-from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
+from twilio.twiml.voice_response import Refer, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer(action='/handleRefer', method='POST')

--- a/twiml/voice/refer/refer-4/refer-4.6.x.py
+++ b/twiml/voice/refer/refer-4/refer-4.6.x.py
@@ -1,8 +1,8 @@
-from twilio.twiml.voice_response import Refer, VoiceResponse
+from twilio.twiml.voice_response import Refer, ReferSip, VoiceResponse
 
 response = VoiceResponse()
 refer = Refer(action='/handleRefer', method='POST')
-refer.refer_sip('sip:alice@example.com')
+refer.sip('sip:alice@example.com')
 response.append(refer)
 
 print(response)

--- a/twiml/voice/refer/refer-4/refer-4.7.x.java
+++ b/twiml/voice/refer/refer-4/refer-4.7.x.java
@@ -7,7 +7,7 @@ import com.twilio.http.HttpMethod;
 public class Example {
     public static void main(String[] args) {
         ReferSip sip = new ReferSip.Builder("sip:alice@example.com").build();
-        Refer refer = new Refer.Builder().action("/handleRefer").method(HttpMethod.POST).referSip(number).build();
+        Refer refer = new Refer.Builder().action("/handleRefer").method(HttpMethod.POST).sip(sip).build();
         VoiceResponse response = new VoiceResponse.Builder().refer(refer).build();
 
         try {


### PR DESCRIPTION
`referSip` methods were deprecated; code samples should be updated to reflect this.

(Context from the `twilio-java` library: https://github.com/twilio/twilio-java/blob/main/UPGRADE.md#changed---renamed-nested-twiml-methods)

These code samples were automatically generated and verified with the Twilio twiml generator (https://github.com/TwilioDevEd/twiml-generator).