### PR TITLE
[VIDEO-5254] Fix incorrect curl URL in compositions example.

### DIFF
--- a/video/rest/compositions/get-composition-media-file/get-composition-media-file.json.curl
+++ b/video/rest/compositions/get-composition-media-file/get-composition-media-file.json.curl
@@ -1,2 +1,2 @@
-curl -X GET 'https://video.twilio.com/v1/Composer/CJXXXX/Media?Ttl=3600' \
+curl -X GET 'https://video.twilio.com/v1/Compositions/CJXXXX/Media?Ttl=3600' \
      -u 'SKXXXX:your_api_key_secret'


### PR DESCRIPTION
Fix the incorrect URL in the curl example for get-composition-media-file.