### PR TITLE
[DEVED-4355] Replace SmsSid with MessageSid

### DIFF
--- a/rest/messages/sms-handle-callback/sms-handle-callback.5.x.cs
+++ b/rest/messages/sms-handle-callback/sms-handle-callback.5.x.cs
@@ -10,7 +10,7 @@ public class MessageStatusController : Controller
     public ActionResult Index()
     {
         // Log the message id and status
-        var smsSid = Request.Form["SmsSid"];
+        var smsSid = Request.Form["MessageSid"];
         var messageStatus = Request.Form["MessageStatus"];
         var logMessage = $"\"{smsSid}\", \"{messageStatus}\"";
 


### PR DESCRIPTION
This commit replaces `SmsSid` (deprecated but remains for backwards compatibility) with `MessageSid` in the C# codesample for handling an SMS StatusCallback.