### PR TITLE
DEVED-5693: Fix incorrect example for nodejs getting composition media.

### DIFF
--- a/video/rest/compositions/get-composition-media-file/get-composition-media-file.3.x.js
+++ b/video/rest/compositions/get-composition-media-file/get-composition-media-file.3.x.js
@@ -27,7 +27,7 @@ client
   .then((response) => {
     // For example, download the media to a local file
     const file = fs.createWriteStream("myFile.mp4");
-    const r = request(response.data.redirect_to);
+    const r = request(response.body.redirect_to);
     r.on("response", (res) => {
       res.pipe(file);
     });


### PR DESCRIPTION
Jira: https://issues.corp.twilio.com/browse/DEVED-5693

https://www.twilio.com/docs/video/api/compositions-resource#get-composition-media-file-http-get
Using `response.data` returns undefined. This should be accessing `response.body`.