### PR TITLE
Update client identifier to use underscores instead of hyphens

### DIFF
--- a/twiml/voice/parameter/parameter-1/output/parameter-1.twiml
+++ b/twiml/voice/parameter/parameter-1/output/parameter-1.twiml
@@ -2,7 +2,7 @@
 <Response>
    <Dial>
      <Client>
-        <Identity>user-jane</Identity>
+        <Identity>user_jane</Identity>
         <Parameter name="FirstName" value ="Jane"/>
         <Parameter name="LastName" value ="Doe" />
       </Client>

--- a/twiml/voice/parameter/parameter-1/parameter-1.3.x.js
+++ b/twiml/voice/parameter/parameter-1/parameter-1.3.x.js
@@ -3,7 +3,7 @@ const VoiceResponse = require('twilio').twiml.VoiceResponse;
 const response = new VoiceResponse();
 const dial = response.dial();
 const client = dial.client();
-client.identity('user-jane');
+client.identity('user_jane');
 client.parameter({
     name: 'FirstName',
     value: 'Jane'

--- a/twiml/voice/parameter/parameter-1/parameter-1.5.x.cs
+++ b/twiml/voice/parameter/parameter-1/parameter-1.5.x.cs
@@ -10,7 +10,7 @@ class Example
         var response = new VoiceResponse();
         var dial = new Dial();
         var client = new Client();
-        client.Identity("user-jane");
+        client.Identity("user_jane");
         client.Parameter(name: "FirstName", value: "Jane");
         client.Parameter(name: "LastName", value: "Doe");
         dial.Append(client);

--- a/twiml/voice/parameter/parameter-1/parameter-1.5.x.php
+++ b/twiml/voice/parameter/parameter-1/parameter-1.5.x.php
@@ -5,7 +5,7 @@ use Twilio\TwiML\VoiceResponse;
 $response = new VoiceResponse();
 $dial = $response->dial('');
 $client = $dial->client();
-$client->identity('user-jane');
+$client->identity('user_jane');
 $client->parameter(['name' => 'FirstName', 'value' => 'Jane']);
 $client->parameter(['name' => 'LastName', 'value' => 'Doe']);
 

--- a/twiml/voice/parameter/parameter-1/parameter-1.6.x.php
+++ b/twiml/voice/parameter/parameter-1/parameter-1.6.x.php
@@ -5,7 +5,7 @@ use Twilio\TwiML\VoiceResponse;
 $response = new VoiceResponse();
 $dial = $response->dial('');
 $client = $dial->client();
-$client->identity('user-jane');
+$client->identity('user_jane');
 $client->parameter(['name' => 'FirstName', 'value' => 'Jane']);
 $client->parameter(['name' => 'LastName', 'value' => 'Doe']);
 

--- a/twiml/voice/parameter/parameter-1/parameter-1.6.x.py
+++ b/twiml/voice/parameter/parameter-1/parameter-1.6.x.py
@@ -3,7 +3,7 @@ from twilio.twiml.voice_response import Client, Dial, Identity, Parameter, Voice
 response = VoiceResponse()
 dial = Dial()
 client = Client()
-client.identity('user-jane')
+client.identity('user_jane')
 client.parameter(name='FirstName', value='Jane')
 client.parameter(name='LastName', value='Doe')
 dial.append(client)

--- a/twiml/voice/parameter/parameter-1/parameter-1.7.x.java
+++ b/twiml/voice/parameter/parameter-1/parameter-1.7.x.java
@@ -8,7 +8,7 @@ import com.twilio.twiml.TwiMLException;
 
 public class Example {
     public static void main(String[] args) {
-        Identity identity = new Identity.Builder("user-jane").build();
+        Identity identity = new Identity.Builder("user_jane").build();
         Parameter parameter = new Parameter.Builder().name("FirstName").value("Jane").build();
         Parameter parameter2 = new Parameter.Builder().name("LastName").value("Doe").build();
         Client client = new Client.Builder().identity(identity).parameter(parameter).parameter(parameter2).build();

--- a/twiml/voice/parameter/parameter-1/parameter-1.8.x.java
+++ b/twiml/voice/parameter/parameter-1/parameter-1.8.x.java
@@ -8,7 +8,7 @@ import com.twilio.twiml.TwiMLException;
 
 public class Example {
     public static void main(String[] args) {
-        Identity identity = new Identity.Builder("user-jane").build();
+        Identity identity = new Identity.Builder("user_jane").build();
         Parameter parameter = new Parameter.Builder().name("FirstName")
             .value("Jane").build();
         Parameter parameter2 = new Parameter.Builder().name("LastName")

--- a/twiml/voice/parameter/parameter-1/parameter-5.x.rb
+++ b/twiml/voice/parameter/parameter-1/parameter-5.x.rb
@@ -3,7 +3,7 @@ require 'twilio-ruby'
 response = Twilio::TwiML::VoiceResponse.new
 response.dial do |dial|
     dial.client do |client|
-        client.identity('user-jane')
+        client.identity('user_jane')
         client.parameter(name: 'FirstName', value: 'Jane')
         client.parameter(name: 'LastName', value: 'Doe')
 end


### PR DESCRIPTION
As per the warning on [this page:](https://www.twilio.com/docs/voice/twiml/client) "The client identifier currently may only contain alpha-numeric and underscore characters."

This PR updates the snippets from 'user-jane' to 'user_jane' to reduce confusion for the user. 