### PR TITLE
Add samples for listing Usage Records with Twilio CLI

### DIFF
--- a/rest/usage-records/list-get-example-1/list-get-example-1.2.x.cli
+++ b/rest/usage-records/list-get-example-1/list-get-example-1.2.x.cli
@@ -1,0 +1,3 @@
+# Install the twilio-cli from https://twil.io/cli
+
+twilio api:core:usage:records:last-month:list

--- a/rest/usage-records/list-get-example-2/list-get-example-2.2.x.cli
+++ b/rest/usage-records/list-get-example-2/list-get-example-2.2.x.cli
@@ -1,0 +1,4 @@
+# Install the twilio-cli from https://twil.io/cli
+
+twilio api:core:usage:records:today:list \
+    --category=calls

--- a/rest/usage-records/list-get-example-3/list-get-example-3.2.x.cli
+++ b/rest/usage-records/list-get-example-3/list-get-example-3.2.x.cli
@@ -1,0 +1,6 @@
+# Install the twilio-cli from https://twil.io/cli
+
+twilio api:core:usage:records:list \
+    --start-date=2012-09-01 \
+    --end-date=2012-09-30 \
+    --category=calls-inbound

--- a/rest/usage-records/list-get-example-4/list-get-example-4.2.x.cli
+++ b/rest/usage-records/list-get-example-4/list-get-example-4.2.x.cli
@@ -1,0 +1,6 @@
+# Install the twilio-cli from https://twil.io/cli
+
+twilio api:core:usage:records:daily:list \
+    --start-date=2012-09-01 \
+    --end-date=2012-09-30 \
+    --category=calls-inbound

--- a/rest/usage-records/list-get-example-5/list-get-example-5.2.x.cli
+++ b/rest/usage-records/list-get-example-5/list-get-example-5.2.x.cli
@@ -1,0 +1,3 @@
+# Install the twilio-cli from https://twil.io/cli
+
+twilio api:core:usage:records:all-time:list


### PR DESCRIPTION
This change adds Twilio CLI 2.x samples to the existing collection of samples that illustrate how to list [Usage Records](https://www.twilio.com/docs/usage/api/usage-record#).