### PR TITLE
remove wrong call to 'accounts' method

### DIFF
--- a/rest/messages/feedback-confirm/feedback-confirm.3.x.js
+++ b/rest/messages/feedback-confirm/feedback-confirm.3.x.js
@@ -19,7 +19,6 @@ app.get('/confirm', (req, res) => {
 
   // Send Feedback to Twilio
   client
-    .accounts(accountSid)
     .messages(messageSid)
     .feedback.create({
       outcome: 'confirmed',


### PR DESCRIPTION
I was using node.js and it was not working for me, then I checked how it was in other languages and I saw this was wrongly being used there. I guess the account SID is already set in the `client` instantiation.