### PR TITLE
fix: standardize Runtime mobile sample code

### DIFF
--- a/guides/functions/joke-function/joke-function.3.x.js
+++ b/guides/functions/joke-function/joke-function.3.x.js
@@ -1,4 +1,4 @@
-exports.handler = function(context, event, callback) {
+exports.handler = (context, event, callback) => {
   const joke = 'How many apples grow on a tree? They all do!';
-  callback(null, joke);
+  return callback(null, joke);
 };

--- a/guides/functions/jokes-function/jokes-function.3.x.js
+++ b/guides/functions/jokes-function/jokes-function.3.x.js
@@ -1,4 +1,4 @@
-exports.handler = function(context, event, callback) {
+exports.handler = (context, event, callback) => {
   const knockKnock = { id: 1, text: 'Knock, knock', favorited: 37 };
   const chicken = {
     id: 2,
@@ -6,5 +6,5 @@ exports.handler = function(context, event, callback) {
     favorited: 12,
   };
   const jokes = [knockKnock, chicken];
-  callback(null, jokes);
+  return callback(null, jokes);
 };


### PR DESCRIPTION
Part of our revamp of the Runtime docs has included consistently using ES6 arrow functions as well as making sure users get in the habit of using `return callback` instead of just `callback`. It's not technically an issue for these examples, but it helps with the consistency of our samples and messaging :) 