### PR TITLE
Add example for subscribing a Media Transcriber to a single Room Participant.

### DIFF
--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/meta.json
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Use Subscribe Rules to transcribe audio for a specific Participant",
+  "type": "server"
+}

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/output/update-customer-rules.json
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/output/update-customer-rules.json
@@ -1,0 +1,9 @@
+{
+  "room_sid": "RMXXXX",
+  "participant_sid": "PAXXXX",
+  "rules": [
+    {"type": "include", "publisher": "Instructor"}
+  ],
+  "date_updated": "2022-04-30T20:28:00Z",
+  "date_created": "2022-04-30T20:15:49Z"
+}

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.3.x.js
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.3.x.js
@@ -1,0 +1,26 @@
+// NOTE: This example uses the next generation Twilio helper library - for more
+// information on how to download and install this version, visit
+// https://www.twilio.com/docs/libraries/node
+
+// Find your credentials at twilio.com/console
+// To set up environmental variables, see http://twil.io/secure
+const API_KEY_SID = process.env.TWILIO_API_KEY;
+const API_KEY_SECRET = process.env.TWILIO_API_KEY_SECRET;
+const ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID;
+
+const Twilio = require('twilio');
+
+const client = new Twilio(API_KEY_SID, API_KEY_SECRET, {accountSid: ACCOUNT_SID});
+
+client.video.rooms('RMXXXX').participants.get('media-transcriber')
+.subscribeRules.update({
+  rules: [
+    {"type": "include", "publisher": "Instructor"}
+  ]
+})
+.then(result => {
+  console.log('Subscribe Rules updated successfully')
+})
+.catch(error => {
+  console.log('Error updating rules ' + error)
+});

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.5.x.cs
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.5.x.cs
@@ -1,0 +1,34 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using System.Collections.Generic;
+using Twilio;
+using Twilio.Rest.Video.V1;
+using static Twilio.Rest.Video.V1.Participant;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // Find your API Key SID and Secret at twilio.com/console
+        // To set up environmental variables, see http://twil.io/secure
+        const string apiKeySid = Environment.GetEnvironmentVariable("TWILIO_API_KEY_SID");
+        const string apiKeySecret = Environment.GetEnvironmentVariable("TWILIO_API_KEY_SECRET");
+
+        TwilioClient.Init(apiKeySid, apiKeySecret);
+
+        var rules = new[]
+        {
+                new Dictionary<string,object>(){
+                    {"type", "include"}, {"publisher", "Instructor"}
+                },
+        };
+
+        SubscribeRulesResource.Update(
+            "RMXXXX",
+            "media-transcriber",
+            rules);
+
+        Console.WriteLine("Subscribe Rules updated successfully");
+    }
+}

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.5.x.rb
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.5.x.rb
@@ -1,0 +1,19 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Find your credentials at twilio.com/console
+# To set up environmental variables, see http://twil.io/secure
+api_key_sid = ENV['TWILIO_API_KEY']
+api_key_secret = ENV['TWILIO_API_KEY_SECRET']
+
+@client = Twilio::REST::Client.new(api_key_sid, api_key_secret)
+
+@client.video.rooms('RMXXXX').participants('media-transcriber')
+.subscribe_rules.update(
+  rules: [
+    {"type": "include", "publisher": "Instructor"}
+  ]
+)
+
+puts 'Subscribe Rules updated successfully'

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.6.x.php
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.6.x.php
@@ -1,0 +1,15 @@
+<?php
+// Get the PHP helper library from https://twilio.com/docs/libraries/php
+require_once '/path/to/vendor/autoload.php'; // Loads the library
+use Twilio\Rest\Client;
+
+// Find your credentials at twilio.com/console
+// To set up environmental variables, see http://twil.io/secure
+$sid = getenv('TWILIO_ACCOUNT_SID');
+$token = getenv('TWILIO_AUTH_TOKEN');
+$client = new Client($sid, $token);
+
+$client->video->rooms('RMXXXX')->participants('media-transcriber')
+->subscribeRules->update(“rules” => [[“type” => “include”, “publisher” => "Instructor"]]);
+
+echo 'Subscribe Rules updated successfully';

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.7.x.py
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.7.x.py
@@ -1,0 +1,19 @@
+# Download the Python helper library from twilio.com/docs/python/install
+import os
+from twilio.rest import Client
+import json
+
+# Find your credentials at twilio.com/console
+# To set up environmental variables, see http://twil.io/secure
+account_sid = os.environ['TWILIO_ACCOUNT_SID’]
+auth_token = os.environ['TWILIO_AUTH_TOKEN’]
+client = Client(account_sid, auth_token)
+
+client.video.rooms('RMXXXX').participants.get('media-transcriber')\
+.subscribe_rules.update(
+    rules = [
+        {"type": "include", "publisher": "Instructor"}
+    ]
+)
+
+print('Subscribe Rules updated successfully')

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.8.x.java
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.8.x.java
@@ -1,0 +1,36 @@
+// Install the Java helper library from twilio.com/docs/java/install
+import com.twilio.Twilio;
+import com.twilio.rest.video.v1.room.participant.SubscribeRules;
+import com.twilio.rest.video.v1.Room.Participants;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class UpdateRules{
+
+  // Find your credentials at twilio.com/console
+  // To set up environment variables, see http://twil.io/secure
+  public static final String ACCOUNT_SID = System.getenv("TWILIO_ACCOUNT_SID");
+  public static final String AUTH_TOKEN = System.getenv("TWILIO_AUTH_TOKEN”);
+
+  public static void main( String[] args ) throws IOException{
+      // Initialize the client
+      Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+
+      SubscribeRulesUpdate rules = new SubscribeRulesUpdate(Lists.newArrayList(
+
+              SubscribeRule.builder()
+              .withType(SubscribeRule.Type.INCLUDE).withPublisher("Instructor")
+              .build()
+          ));
+
+      SubscribeRules result = SubscribeRules
+      .updater("RMXXXX", "media-transcriber")
+      .setRules(new ObjectMapper().convertValue(rules, Map.class))
+      .update();
+
+      System.out.println("Subscribe Rules updated successfully");
+
+
+
+  }
+}

--- a/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.json.curl
+++ b/video/rest/rooms/participants/unsubscribe-media-transcriber/update-customer-rules.json.curl
@@ -1,0 +1,4 @@
+curl -X POST 'https://video.twilio.com/v1/Rooms/RMXXXX/Participants/Customer/SubscribeRules' \
+    -u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN \
+    --data Rules='[{"type": "include", "publisher": "Instructor"}]' \
+    -H "Content-Type: application/x-www-form-urlencoded"


### PR DESCRIPTION
This essentially copies the code from [an existing code sample](https://github.com/TwilioDevEd/api-snippets/tree/master/video/rest/rooms/participants/update-subscribe-rules-static) and only changes the specific rule being applied.