### PR TITLE
feat: add Go samples for messaging twiml + validation examples

### DIFF
--- a/guides/request-validation-gin/example-1/example-1.1.x.go
+++ b/guides/request-validation-gin/example-1/example-1.1.x.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/client"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func requireValidTwilioSignature(validator *client.RequestValidator) gin.HandlerFunc {
+	return func(context *gin.Context) {
+		// Your url will vary depending on your environment and how your application is deployed
+		// Modify this url declaration sample as necessary
+		url := "https://some-digits.ngrok.io" + context.Request.URL.Path
+		signatureHeader := context.Request.Header.Get("X-Twilio-Signature")
+		params := make(map[string]string)
+		context.Request.ParseForm()
+		for key, value := range context.Request.PostForm {
+			params[key] = value[0]
+		}
+
+		// Requests are validated based on the incoming url, parameters,
+		// and the X-Twilio-Signature header.
+		// If the request is not valid, return a 403 error
+		if !validator.Validate(url, params, signatureHeader) {
+			fmt.Println("Request isn't from Twilio 🚫")
+			context.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		// If the request is valid, execute the next middleware (in this case, the route handler)
+		context.Next()
+	}
+}
+
+func main() {
+	router := gin.Default()
+	// Create a RequestValidator instance
+	requestValidator := client.NewRequestValidator(os.Getenv("TWILIO_AUTH_TOKEN"))
+
+	// Apply the requireValidTwilioSignature to your route handler(s), before any code that you want
+	// to only apply to validated requests
+	router.POST("/sms", requireValidTwilioSignature(&requestValidator), func(context *gin.Context) {
+		message := &twiml.MessagingMessage{
+			Body: "Yay, valid requests!",
+		}
+
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err.Error())
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
+	})
+
+	router.Run(":3000")
+}

--- a/guides/request-validation-gin/example-1/meta.json
+++ b/guides/request-validation-gin/example-1/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Custom middleware for Gin projects to validate Twilio requests",
+  "description": "Confirm incoming requests to your Gin routes are genuine with this custom middleware.",
+  "type": "server"
+}

--- a/guides/request-validation-gin/example-2/example-2.1.x.go
+++ b/guides/request-validation-gin/example-2/example-2.1.x.go
@@ -1,0 +1,74 @@
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/client"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+// The init function is a great place to prepare application state prior to execution
+// In this case, parsing input flags to your app
+func init() {
+	testing.Init()
+	flag.Parse()
+}
+
+// Helper method to determine if your Go code is being run in test mode
+func IsTestRun() bool {
+	return flag.Lookup("test.v").Value.(flag.Getter).Get().(bool)
+	// Some teams may prefer to use env vars to indicate testing instead, such as
+	// return os.Getenv("GO_ENV") == "testing"
+}
+
+func requireValidTwilioSignature(validator *client.RequestValidator) gin.HandlerFunc {
+	return func(context *gin.Context) {
+		// Your url will vary depending on your environment and how your application is deployed
+		// Modify this url declaration sample as necessary
+		url := "https://some-digits.ngrok.io" + context.Request.URL.Path
+		signatureHeader := context.Request.Header.Get("X-Twilio-Signature")
+		params := make(map[string]string)
+		context.Request.ParseForm()
+		for key, value := range context.Request.PostForm {
+			params[key] = value[0]
+		}
+
+		// Requests are validated based on the incoming url, parameters,
+		// and the X-Twilio-Signature header.
+		// If the request is not valid AND this isn't being run in a test env, return a 403 error
+		if !validator.Validate(url, params, signatureHeader) && !IsTestRun() {
+			fmt.Println("Request isn't from Twilio 🚫")
+			context.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		// If the request is valid, execute the next middleware (in this case, the route handler)
+		context.Next()
+	}
+}
+
+func main() {
+	router := gin.Default()
+	// Create a RequestValidator instance
+	requestValidator := client.NewRequestValidator(os.Getenv("TWILIO_AUTH_TOKEN"))
+
+	// Apply the requireValidTwilioSignature to your route handler(s), before any code that you want
+	// to only apply to validated requests
+	router.POST("/sms", requireValidTwilioSignature(&requestValidator), func(context *gin.Context) {
+		message := &twiml.MessagingMessage{
+			Body: "Yay, valid requests!",
+		}
+
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err.Error())
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
+	})
+
+	router.Run(":3000")
+}

--- a/guides/request-validation-gin/example-2/meta.json
+++ b/guides/request-validation-gin/example-2/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Disable Twilio webhook middleware when testing Gin routes.",
+  "description": "Disable webhook validation during testing.",
+  "type": "server"
+}

--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
@@ -27,10 +27,13 @@ func main() {
 			Body: body,
 		}
 
-		twimlResult, _ := twiml.Messages([]twiml.Element{message})
-
-		context.Header("Content-Type", "text/xml")
-		context.String(http.StatusOK, twimlResult)
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err)
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
 	})
 
 	router.Run(":3000")

--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	router := gin.Default()
 
-	router.POST("/handle-sms", func(context *gin.Context) {
+	router.POST("/sms", func(context *gin.Context) {
 		incomingBody := strings.ToLower(strings.TrimSpace(context.PostForm("Body")))
 
 		var body string
@@ -26,6 +26,7 @@ func main() {
 		message := &twiml.MessagingMessage{
 			Body: body,
 		}
+
 		twimlResult, _ := twiml.Messages([]twiml.Element{message})
 
 		context.Header("Content-Type", "text/xml")

--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.POST("/handle-sms", func(context *gin.Context) {
+		incomingBody := strings.ToLower(strings.TrimSpace(context.PostForm("Body")))
+
+		var body string
+		if incomingBody == "hello" {
+			body = "Hi!"
+		} else if incomingBody == "bye" {
+			body = "Goodbye"
+		} else {
+			body = "No Body param match, Twilio sends this in the request to your server."
+		}
+
+		message := &twiml.MessagingMessage{
+			Body: body,
+		}
+		twimlResult, _ := twiml.Messages([]twiml.Element{message})
+
+		context.Header("Content-Type", "text/xml")
+		context.String(http.StatusOK, twimlResult)
+	})
+
+	router.Run(":3000")
+}

--- a/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
+++ b/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.POST("/sms", func(context *gin.Context) {
+		message := &twiml.MessagingMessage{
+			InnerElements: []twiml.Element{
+				twiml.MessagingBody{
+					Message: "The Robots are coming! Head for the hills!",
+				},
+				twiml.MessagingMedia{
+					Url: "https://farm8.staticflickr.com/7090/6941316406_80b4d6d50e_z_d.jpg",
+				},
+			},
+		}
+
+		twimlResult, _ := twiml.Messages([]twiml.Element{message})
+
+		context.Header("Content-Type", "text/xml; charset=\"utf-8\"")
+		context.String(http.StatusOK, twimlResult)
+	})
+
+	router.Run(":3000")
+}

--- a/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
+++ b/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
@@ -21,10 +21,13 @@ func main() {
 			InnerElements: []twiml.Element{messageBody, messageMedia},
 		}
 
-		twimlResult, _ := twiml.Messages([]twiml.Element{message})
-
-		context.Header("Content-Type", "text/xml")
-		context.String(http.StatusOK, twimlResult)
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err)
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
 	})
 
 	router.Run(":3000")

--- a/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
+++ b/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
@@ -11,20 +11,19 @@ func main() {
 	router := gin.Default()
 
 	router.POST("/sms", func(context *gin.Context) {
+		messageBody := twiml.MessagingBody{
+			Message: "The Robots are coming! Head for the hills!",
+		}
+		messageMedia := twiml.MessagingMedia{
+			Url: "https://farm8.staticflickr.com/7090/6941316406_80b4d6d50e_z_d.jpg",
+		}
 		message := &twiml.MessagingMessage{
-			InnerElements: []twiml.Element{
-				twiml.MessagingBody{
-					Message: "The Robots are coming! Head for the hills!",
-				},
-				twiml.MessagingMedia{
-					Url: "https://farm8.staticflickr.com/7090/6941316406_80b4d6d50e_z_d.jpg",
-				},
-			},
+			InnerElements: []twiml.Element{messageBody, messageMedia},
 		}
 
 		twimlResult, _ := twiml.Messages([]twiml.Element{message})
 
-		context.Header("Content-Type", "text/xml; charset=\"utf-8\"")
+		context.Header("Content-Type", "text/xml")
 		context.String(http.StatusOK, twimlResult)
 	})
 

--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.POST("/handle-sms", func(context *gin.Context) {
+		message := &twiml.MessagingMessage{
+			Body: "The Robots are coming! Head for the hills!",
+		}
+		twimlResult, _ := twiml.Messages([]twiml.Element{message})
+
+		context.Header("Content-Type", "text/xml")
+		context.String(http.StatusOK, twimlResult)
+	})
+
+	router.Run(":3000")
+}

--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
@@ -10,10 +10,11 @@ import (
 func main() {
 	router := gin.Default()
 
-	router.POST("/handle-sms", func(context *gin.Context) {
+	router.POST("/sms", func(context *gin.Context) {
 		message := &twiml.MessagingMessage{
 			Body: "The Robots are coming! Head for the hills!",
 		}
+
 		twimlResult, _ := twiml.Messages([]twiml.Element{message})
 
 		context.Header("Content-Type", "text/xml")

--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
@@ -15,10 +15,13 @@ func main() {
 			Body: "The Robots are coming! Head for the hills!",
 		}
 
-		twimlResult, _ := twiml.Messages([]twiml.Element{message})
-
-		context.Header("Content-Type", "text/xml")
-		context.String(http.StatusOK, twimlResult)
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err)
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
 	})
 
 	router.Run(":3000")


### PR DESCRIPTION
Adds Golang support for Messaging TwiML samples, such as when running a server that needs to respond to an incoming message with an SMS/MMS in kind.

Also adds example servers for validating incoming webhook requests