### PR TITLE
Fix compiler error on line 20

### DIFF
--- a/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
+++ b/rest/messages/generate-twiml-sms/generate-twiml-sms.1.x.go
@@ -17,7 +17,7 @@ func main() {
 
 		twimlResult, err := twiml.Messages([]twiml.Element{message})
 		if err != nil {
-			context.String(http.StatusInternalServerError, err)
+			context.String(http.StatusInternalServerError, err.Error())
 		} else {
 			context.Header("Content-Type", "text/xml")
 			context.String(http.StatusOK, twimlResult)


### PR DESCRIPTION
This snippet gives a compiler warning that you cannot assign an error type to a string, err.Error() casts it correcty and allows it to compile. 

Original code gives this compiler error: cannot use err (variable of type error) as string value in argument to context.String