### PR TITLE
fix: incorrect error casting to string

### DIFF
--- a/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
+++ b/rest/messages/generate-twiml-dynamic-sms/generate-twiml-dynamic-sms.1.x.go
@@ -29,7 +29,7 @@ func main() {
 
 		twimlResult, err := twiml.Messages([]twiml.Element{message})
 		if err != nil {
-			context.String(http.StatusInternalServerError, err)
+			context.String(http.StatusInternalServerError, err.Error())
 		} else {
 			context.Header("Content-Type", "text/xml")
 			context.String(http.StatusOK, twimlResult)

--- a/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
+++ b/rest/messages/generate-twiml-mms/generate-twiml-mms.1.x.go
@@ -23,7 +23,7 @@ func main() {
 
 		twimlResult, err := twiml.Messages([]twiml.Element{message})
 		if err != nil {
-			context.String(http.StatusInternalServerError, err)
+			context.String(http.StatusInternalServerError, err.Error())
 		} else {
 			context.Header("Content-Type", "text/xml")
 			context.String(http.StatusOK, twimlResult)


### PR DESCRIPTION
As discovered by #997, some of my messaging-related samples were passing `err` directly instead of calling `err.Error()` (embarrassing since I did it corectly with `err.Error()` in the Voice and request validation samples 🤦 ). Fixing this for remaining Golang samples while it's on my mind :)

