### PR TITLE
Deved 7913 - Add <Dial><Application> TwiML examples

### DIFF
--- a/twiml/voice/application/dial-application-basic/dial-application-basic.4.x.js
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.4.x.js
@@ -1,0 +1,8 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const dial = response.dial();
+const application = dial.application();
+application.applicationSid('AP1234567890abcdef1234567890abcd');
+
+console.log(response.toString());

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.5.x.rb
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.dial do |dial|
+    dial.application do |application|
+        application.application_sid('AP1234567890abcdef1234567890abcd')
+end
+end
+
+puts response

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.cs
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.cs
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application()
+application.application_sid('AP1234567890abcdef1234567890abcd')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.cs
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.cs
@@ -1,10 +1,19 @@
-from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
 
-response = VoiceResponse()
-dial = Dial()
-application = Application()
-application.application_sid('AP1234567890abcdef1234567890abcd')
-dial.append(application)
-response.append(dial)
 
-print(response)
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var dial = new Dial();
+        var application = new Application();
+        application.ApplicationSid("AP1234567890abcdef1234567890abcd");
+        dial.Append(application);
+        response.Append(dial);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.php
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.6.x.php
@@ -1,0 +1,10 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$dial = $response->dial('');
+$application = $dial->application();
+$application->applicationsid('AP1234567890abcdef1234567890abcd');
+
+echo $response;

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.7.x.py
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.7.x.py
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application()
+application.application_sid('AP1234567890abcdef1234567890abcd')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-basic/dial-application-basic.9.x.java
+++ b/twiml/voice/application/dial-application-basic/dial-application-basic.9.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Application;
+import com.twilio.twiml.voice.ApplicationSid;
+import com.twilio.twiml.voice.Dial;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        ApplicationSid applicationsid = new ApplicationSid.Builder("AP1234567890abcdef1234567890abcd").build();
+        Application application = new Application.Builder().applicationSid(applicationsid).build();
+        Dial dial = new Dial.Builder().application(application).build();
+        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/dial-application-basic/meta.json
+++ b/twiml/voice/application/dial-application-basic/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "Basic <Dial><Application>",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/dial-application-basic/output/dial-application-basic.twiml
+++ b/twiml/voice/application/dial-application-basic/output/dial-application-basic.twiml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial>
+    <Application>
+      <ApplicationSid>AP1234567890abcdef1234567890abcd</ApplicationSid>
+    </Application>
+  </Dial>
+</Response>

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.4.x.js
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.4.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const dial = response.dial();
+const application = dial.application({
+    copyParentTo: true
+});
+application.applicationSid('AP1234567890abcdef1234567890abcd');
+
+console.log(response.toString());

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.5.x.rb
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.dial do |dial|
+    dial.application(copy_parent_to: true) do |application|
+        application.application_sid('AP1234567890abcdef1234567890abcd')
+end
+end
+
+puts response

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.6.x.cs
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.6.x.cs
@@ -1,0 +1,19 @@
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var dial = new Dial();
+        var application = new Application(copyParentTo: true);
+        application.ApplicationSid("AP1234567890abcdef1234567890abcd");
+        dial.Append(application);
+        response.Append(dial);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.6.x.php
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.6.x.php
@@ -1,0 +1,11 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$dial = $response->dial('');
+$application = $dial->application();
+$application->applicationsid('AP1234567890abcdef1234567890abcd');
+$application->setCopyParentTo('true');
+
+echo $response;

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.7.x.py
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.7.x.py
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application(copy_parent_to=True)
+application.application_sid('AP1234567890abcdef1234567890abcd')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.9.x.java
+++ b/twiml/voice/application/dial-application-copyparentto/dial-application-copyparentto.9.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Application;
+import com.twilio.twiml.voice.ApplicationSid;
+import com.twilio.twiml.voice.Dial;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        ApplicationSid applicationsid = new ApplicationSid.Builder("AP1234567890abcdef1234567890abcd").build();
+        Application application = new Application.Builder().copyParentTo(true).applicationSid(applicationsid).build();
+        Dial dial = new Dial.Builder().application(application).build();
+        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/dial-application-copyparentto/meta.json
+++ b/twiml/voice/application/dial-application-copyparentto/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Dial><Application> with copyParentTo attribute",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/dial-application-copyparentto/output/dial-application-copyparentto.twiml
+++ b/twiml/voice/application/dial-application-copyparentto/output/dial-application-copyparentto.twiml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial>
+    <Application copyParentTo="true">
+      <ApplicationSid>AP1234567890abcdef1234567890abcd</ApplicationSid>
+    </Application>
+  </Dial>
+</Response>

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.4.x.js
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.4.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const dial = response.dial();
+const application = dial.application({
+    customerId: 'CustomerFriendlyName'
+});
+application.applicationSid('AP1234567890abcdef1234567890abcd');
+
+console.log(response.toString());

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.5.x.rb
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.5.x.rb
@@ -1,0 +1,10 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.dial do |dial|
+    dial.application(customer_id: 'CustomerFriendlyName') do |application|
+        application.application_sid('AP1234567890abcdef1234567890abcd')
+end
+end
+
+puts response

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.cs
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.cs
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application(customer_id='CustomerFriendlyName')
+application.application_sid('AP1234567890abcdef1234567890abcd')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.cs
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.cs
@@ -1,10 +1,19 @@
-from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
 
-response = VoiceResponse()
-dial = Dial()
-application = Application(customer_id='CustomerFriendlyName')
-application.application_sid('AP1234567890abcdef1234567890abcd')
-dial.append(application)
-response.append(dial)
 
-print(response)
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var dial = new Dial();
+        var application = new Application(customerId: "CustomerFriendlyName");
+        application.ApplicationSid("AP1234567890abcdef1234567890abcd");
+        dial.Append(application);
+        response.Append(dial);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.php
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.6.x.php
@@ -1,0 +1,11 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$dial = $response->dial('');
+$application = $dial->application();
+$application->applicationsid('AP1234567890abcdef1234567890abcd');
+$application->setCustomerId('CustomerFriendlyName');
+
+echo $response;

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.7.x.py
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.7.x.py
@@ -1,0 +1,10 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application(customer_id='CustomerFriendlyName')
+application.application_sid('AP1234567890abcdef1234567890abcd')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-customerid/dial-application-customerid.9.x.java
+++ b/twiml/voice/application/dial-application-customerid/dial-application-customerid.9.x.java
@@ -1,0 +1,21 @@
+import com.twilio.twiml.voice.Application;
+import com.twilio.twiml.voice.ApplicationSid;
+import com.twilio.twiml.voice.Dial;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        ApplicationSid applicationsid = new ApplicationSid.Builder("AP1234567890abcdef1234567890abcd").build();
+        Application application = new Application.Builder().customerId("CustomerFriendlyName").applicationSid(applicationsid).build();
+        Dial dial = new Dial.Builder().application(application).build();
+        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/dial-application-customerid/meta.json
+++ b/twiml/voice/application/dial-application-customerid/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Dial><Application> with customerId attribute",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/dial-application-customerid/output/dial-application-customerid.twiml
+++ b/twiml/voice/application/dial-application-customerid/output/dial-application-customerid.twiml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial>
+    <Application customerId="CustomerFriendlyName">
+      <ApplicationSid>AP1234567890abcdef1234567890abcd</ApplicationSid>
+    </Application>
+  </Dial>
+</Response>

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.4.x.js
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.4.x.js
@@ -1,0 +1,16 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const dial = response.dial();
+const application = dial.application();
+application.applicationSid('AP1234567890abcdef1234567890abcd');
+application.parameter({
+    name: 'AccountNumber',
+    value: '12345'
+});
+application.parameter({
+    name: 'TicketNumber',
+    value: '9876'
+});
+
+console.log(response.toString());

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.5.x.rb
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.5.x.rb
@@ -1,0 +1,12 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.dial do |dial|
+    dial.application do |application|
+        application.application_sid('AP1234567890abcdef1234567890abcd')
+        application.parameter(name: 'AccountNumber', value: '12345')
+        application.parameter(name: 'TicketNumber', value: '9876')
+end
+end
+
+puts response

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.cs
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.cs
@@ -1,0 +1,12 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, Parameter, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application()
+application.application_sid('AP1234567890abcdef1234567890abcd')
+application.parameter(name='AccountNumber', value='12345')
+application.parameter(name='TicketNumber', value='9876')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.cs
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.cs
@@ -1,12 +1,21 @@
-from twilio.twiml.voice_response import Application, ApplicationSid, Dial, Parameter, VoiceResponse
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
 
-response = VoiceResponse()
-dial = Dial()
-application = Application()
-application.application_sid('AP1234567890abcdef1234567890abcd')
-application.parameter(name='AccountNumber', value='12345')
-application.parameter(name='TicketNumber', value='9876')
-dial.append(application)
-response.append(dial)
 
-print(response)
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var dial = new Dial();
+        var application = new Application();
+        application.ApplicationSid("AP1234567890abcdef1234567890abcd");
+        application.Parameter(name: "AccountNumber", value: "12345");
+        application.Parameter(name: "TicketNumber", value: "9876");
+        dial.Append(application);
+        response.Append(dial);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.php
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.6.x.php
@@ -1,0 +1,12 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$dial = $response->dial('');
+$application = $dial->application();
+$application->applicationsid('AP1234567890abcdef1234567890abcd');
+$application->parameter(['name' => 'AccountNumber', 'value' => '12345']);
+$application->parameter(['name' => 'TicketNumber', 'value' => '9876']);
+
+echo $response;

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.7.x.py
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.7.x.py
@@ -1,0 +1,12 @@
+from twilio.twiml.voice_response import Application, ApplicationSid, Dial, Parameter, VoiceResponse
+
+response = VoiceResponse()
+dial = Dial()
+application = Application()
+application.application_sid('AP1234567890abcdef1234567890abcd')
+application.parameter(name='AccountNumber', value='12345')
+application.parameter(name='TicketNumber', value='9876')
+dial.append(application)
+response.append(dial)
+
+print(response)

--- a/twiml/voice/application/dial-application-parameter/dial-application-parameter.9.x.java
+++ b/twiml/voice/application/dial-application-parameter/dial-application-parameter.9.x.java
@@ -1,0 +1,24 @@
+import com.twilio.twiml.voice.Application;
+import com.twilio.twiml.voice.ApplicationSid;
+import com.twilio.twiml.voice.Dial;
+import com.twilio.twiml.voice.Parameter;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        ApplicationSid applicationsid = new ApplicationSid.Builder("AP1234567890abcdef1234567890abcd").build();
+        Parameter parameter = new Parameter.Builder().name("TicketNumber").value("9876").build();
+        Parameter parameter2 = new Parameter.Builder().name("AccountNumber").value("12345").build();
+        Application application = new Application.Builder().applicationSid(applicationsid).parameter(parameter2).parameter(parameter).build();
+        Dial dial = new Dial.Builder().application(application).build();
+        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/dial-application-parameter/meta.json
+++ b/twiml/voice/application/dial-application-parameter/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Dial><Application> with <Parameter>",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/dial-application-parameter/output/dial-application-parameter.twiml
+++ b/twiml/voice/application/dial-application-parameter/output/dial-application-parameter.twiml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial>
+    <Application>
+      <ApplicationSid>AP1234567890abcdef1234567890abcd</ApplicationSid>
+      <Parameter name="AccountNumber" value="12345"/>
+      <Parameter name="TicketNumber" value="9876"/>
+    </Application>
+  </Dial>
+</Response>

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.4.x.js
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.4.x.js
@@ -1,0 +1,13 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+response.say('We\'re sorry. All of our agents are busy right now.');
+response.say('We will call you back as soon as possible.');
+response.say('Please stay on the line to be redirected to the main menu.');
+const hangup = response.hangup();
+hangup.parameter({
+    name: 'payment_collected',
+    value: false
+});
+
+console.log(response.toString());

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.5.x.rb
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.5.x.rb
@@ -1,0 +1,11 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.say(message: "We're sorry. All of our agents are busy right now.")
+response.say(message: 'We will call you back as soon as possible.')
+response.say(message: 'Please stay on the line to be redirected to the main menu.')
+response.hangup do |hangup|
+    hangup.parameter(name: 'payment_collected', value: false)
+end
+
+puts response

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.6.x.cs
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.6.x.cs
@@ -1,0 +1,20 @@
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        response.Say("We're sorry. All of our agents are busy right now.");
+        response.Say("We will call you back as soon as possible.");
+        response.Say("Please stay on the line to be redirected to the main menu.");
+        var hangup = new Hangup();
+        hangup.Parameter(name: "payment_collected", value: "false");
+        response.Append(hangup);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.6.x.php
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.6.x.php
@@ -1,0 +1,12 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$response->say('We\'re sorry. All of our agents are busy right now.');
+$response->say('We will call you back as soon as possible.');
+$response->say('Please stay on the line to be redirected to the main menu.');
+$hangup = $response->hangup();
+$hangup->parameter(['name' => 'payment_collected', 'value' => 'false']);
+
+echo $response;

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.7.x.py
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.7.x.py
@@ -1,0 +1,11 @@
+from twilio.twiml.voice_response import Hangup, Parameter, VoiceResponse, Say
+
+response = VoiceResponse()
+response.say('We\'re sorry. All of our agents are busy right now.')
+response.say('We will call you back as soon as possible.')
+response.say('Please stay on the line to be redirected to the main menu.')
+hangup = Hangup()
+hangup.parameter(name='payment_collected', value=False)
+response.append(hangup)
+
+print(response)

--- a/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.9.x.java
+++ b/twiml/voice/application/hangup-parameter-scenario/hangup-parameter-scenario.9.x.java
@@ -1,0 +1,23 @@
+import com.twilio.twiml.voice.Hangup;
+import com.twilio.twiml.voice.Parameter;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.voice.Say;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Say say = new Say.Builder("We're sorry. All of our agents are busy right now.").build();
+        Say say2 = new Say.Builder("Please stay on the line to be redirected to the main menu.").build();
+        Parameter parameter = new Parameter.Builder().name("payment_collected").value("false").build();
+        Hangup hangup = new Hangup.Builder().parameter(parameter).build();
+        Say say3 = new Say.Builder("We will call you back as soon as possible.").build();
+        VoiceResponse response = new VoiceResponse.Builder().say(say).say(say3).say(say2).hangup(hangup).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/hangup-parameter-scenario/meta.json
+++ b/twiml/voice/application/hangup-parameter-scenario/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Hangup><Parameter> example scenario",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/hangup-parameter-scenario/output/hangup-parameter-scenario.twiml
+++ b/twiml/voice/application/hangup-parameter-scenario/output/hangup-parameter-scenario.twiml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Say>We're sorry. All of our agents are busy right now.</Say>
+    <Say>We will call you back as soon as possible.</Say>
+    <Say>Please stay on the line to be redirected to the main menu.</Say>
+    <Hangup>
+        <Parameter name="payment_collected" value="false" />
+    </Hangup>
+</Response>

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.4.x.js
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.4.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const hangup = response.hangup();
+hangup.parameter({
+    name: 'hangup_reason',
+    value: 'no agents available'
+});
+
+console.log(response.toString());

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.5.x.rb
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.5.x.rb
@@ -1,0 +1,8 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.hangup do |hangup|
+    hangup.parameter(name: 'hangup_reason', value: 'no agents available')
+end
+
+puts response

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.6.x.cs
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.6.x.cs
@@ -1,0 +1,17 @@
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var hangup = new Hangup();
+        hangup.Parameter(name: "hangup_reason", value: "no agents available");
+        response.Append(hangup);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.6.x.php
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.6.x.php
@@ -1,0 +1,9 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$hangup = $response->hangup();
+$hangup->parameter(['name' => 'hangup_reason', 'value' => 'no agents available']);
+
+echo $response;

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.7.x.py
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.7.x.py
@@ -1,0 +1,8 @@
+from twilio.twiml.voice_response import Hangup, Parameter, VoiceResponse
+
+response = VoiceResponse()
+hangup = Hangup()
+hangup.parameter(name='hangup_reason', value='no agents available')
+response.append(hangup)
+
+print(response)

--- a/twiml/voice/application/hangup-parameter/hangup-parameter.9.x.java
+++ b/twiml/voice/application/hangup-parameter/hangup-parameter.9.x.java
@@ -1,0 +1,19 @@
+import com.twilio.twiml.voice.Hangup;
+import com.twilio.twiml.voice.Parameter;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Parameter parameter = new Parameter.Builder().name("hangup_reason").value("no agents available").build();
+        Hangup hangup = new Hangup.Builder().parameter(parameter).build();
+        VoiceResponse response = new VoiceResponse.Builder().hangup(hangup).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/twiml/voice/application/hangup-parameter/meta.json
+++ b/twiml/voice/application/hangup-parameter/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Hangup><Parameter>",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/hangup-parameter/output/hangup-parameter.twiml
+++ b/twiml/voice/application/hangup-parameter/output/hangup-parameter.twiml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Hangup>
+        <Parameter name="hangup_reason" value="no agents available" />
+    </Hangup>
+</Response>

--- a/twiml/voice/application/reject-parameter/meta.json
+++ b/twiml/voice/application/reject-parameter/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "<Reject><Parameter>",
+    "type": "server"
+  }
+  

--- a/twiml/voice/application/reject-parameter/output/reject-parameter.twiml
+++ b/twiml/voice/application/reject-parameter/output/reject-parameter.twiml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Reject>
+        <Parameter name="reject_reason" value="no agents available" />
+    </Reject>
+</Response>

--- a/twiml/voice/application/reject-parameter/reject-parameter.4.x.js
+++ b/twiml/voice/application/reject-parameter/reject-parameter.4.x.js
@@ -1,0 +1,10 @@
+const VoiceResponse = require('twilio').twiml.VoiceResponse;
+
+const response = new VoiceResponse();
+const reject = response.reject();
+reject.parameter({
+    name: 'reject_reason',
+    value: 'no agents available'
+});
+
+console.log(response.toString());

--- a/twiml/voice/application/reject-parameter/reject-parameter.5.x.rb
+++ b/twiml/voice/application/reject-parameter/reject-parameter.5.x.rb
@@ -1,0 +1,8 @@
+require 'twilio-ruby'
+
+response = Twilio::TwiML::VoiceResponse.new
+response.reject do |reject|
+    reject.parameter(name: 'reject_reason', value: 'no agents available')
+end
+
+puts response

--- a/twiml/voice/application/reject-parameter/reject-parameter.6.x.cs
+++ b/twiml/voice/application/reject-parameter/reject-parameter.6.x.cs
@@ -1,0 +1,17 @@
+using System;
+using Twilio.TwiML;
+using Twilio.TwiML.Voice;
+
+
+class Example
+{
+    static void Main()
+    {
+        var response = new VoiceResponse();
+        var reject = new Reject();
+        reject.Parameter(name: "reject_reason", value: "no agents available");
+        response.Append(reject);
+
+        Console.WriteLine(response.ToString());
+    }
+}

--- a/twiml/voice/application/reject-parameter/reject-parameter.6.x.php
+++ b/twiml/voice/application/reject-parameter/reject-parameter.6.x.php
@@ -1,0 +1,9 @@
+<?php
+require_once './vendor/autoload.php';
+use Twilio\TwiML\VoiceResponse;
+
+$response = new VoiceResponse();
+$reject = $response->reject();
+$reject->parameter(['name' => 'reject_reason', 'value' => 'no agents available']);
+
+echo $response;

--- a/twiml/voice/application/reject-parameter/reject-parameter.7.x.py
+++ b/twiml/voice/application/reject-parameter/reject-parameter.7.x.py
@@ -1,0 +1,8 @@
+from twilio.twiml.voice_response import Parameter, Reject, VoiceResponse
+
+response = VoiceResponse()
+reject = Reject()
+reject.parameter(name='reject_reason', value='no agents available')
+response.append(reject)
+
+print(response)

--- a/twiml/voice/application/reject-parameter/reject-parameter.9.x.java
+++ b/twiml/voice/application/reject-parameter/reject-parameter.9.x.java
@@ -1,0 +1,19 @@
+import com.twilio.twiml.voice.Parameter;
+import com.twilio.twiml.voice.Reject;
+import com.twilio.twiml.VoiceResponse;
+import com.twilio.twiml.TwiMLException;
+
+
+public class Example {
+    public static void main(String[] args) {
+        Parameter parameter = new Parameter.Builder().name("reject_reason").value("no agents available").build();
+        Reject reject = new Reject.Builder().parameter(parameter).build();
+        VoiceResponse response = new VoiceResponse.Builder().reject(reject).build();
+
+        try {
+            System.out.println(response.toXml());
+        } catch (TwiMLException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
✅ I've already verified that these code samples work with the Helper Library version indicated by the file name. 

- Check that the code in the file matches the file extension (no python code in a `.cs` file)
- Check that the attribute that is mention is shown in the examples (ex `copyParentTo` should show up in the `dial-application-copyparentto` examples)
- Check that the meta descriptions match the XML output

### dial-application-basic
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### dial-application-copyparentto
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### dial-application-customerid
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### dial-application-parameter
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### hangup-parameter-scenario
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### hangup-parameter
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example

### reject-parameter
- [ ] an output directory with a `.twiml` file
- [ ] a meta.json file that has a description matching the output in the `.twiml` file
- [ ] a .js example
- [ ] a .rb example
- [ ] a .py example
- [ ] a .cs example
- [ ] a .java example
- [ ] a .php example