### PR TITLE
Add Call to Action code sample for the Content API product

### DIFF
--- a/content-api/call-to-action/call-to-action-example.json.curl
+++ b/content-api/call-to-action/call-to-action-example.json.curl
@@ -1,0 +1,27 @@
+curl -X POST 'https://content.twilio.com/v1/Content' \
+-H 'Content-Type: application/json' \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN \
+-d '{
+  "friendly_name": "flight_departure_update",
+  "language": "en",
+  "variables": {"1": "flight_number",
+                "2": "arrival_city",
+                "3": "departure_time",
+                "4": "gate_number",
+                "5": "url_suffix"},
+  "types": {
+    "twilio/call-to-action": {
+      "body": "Owl Air: We will see you soon! Flight {{1}} to {{2}} departs at {{3}} from Gate {{4}}.",
+      "actions": [{
+          "type": "URL",
+          "title": "Check Flight Status",
+          "url": "https://owlair.com/{{5}}"
+        },
+        {
+          "type": "PHONE_NUMBER",
+          "title": "Call Support",
+          "phone": "+18005551234"
+      }]
+    }
+  }
+}'

--- a/content-api/call-to-action/meta.json
+++ b/content-api/call-to-action/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Call to Action Example",
+  "type": "server"
+}

--- a/content-api/call-to-action/output/call-to-action.json
+++ b/content-api/call-to-action/output/call-to-action.json
@@ -1,0 +1,37 @@
+{
+    "language": "en",
+    "date_updated": "2022-01-15T17:09:58Z",
+    "variables": {
+        "1": "flight_number",
+        "3": "departure_time",
+        "2": "arrival_city",
+        "5": "url_suffix",
+        "4": "gate_number"
+    },
+    "friendly_name": "flight_departure_update",
+    "account_sid": "ACXXXXXXXXXXXXXXXXXXX",
+    "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXX",
+    "sid": "HXXXXXXXXXXXXXXXXXXX",
+    "date_created": "2022-01-15T17:09:58Z",
+    "types": {
+        "twilio/call-to-action": {
+            "body": "Owl Air: We will see you soon! Flight {{1}} to {{2}} departs at {{3}} from Gate {{4}}.",
+            "actions": [
+                {
+                    "url": "https://owlair.com/{{5}}",
+                    "type": "URL",
+                    "title": "Check Flight Status"
+                },
+                {
+                    "phone_number": "+18005551234",
+                    "type": "PHONE_NUMBER",
+                    "title": "Call Support"
+                }
+            ]
+        }
+    },
+    "links": {
+        "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXX/ApprovalRequests",
+        "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp"
+    }
+}


### PR DESCRIPTION
Add Call to Action code sample for the Content API product per #help-docs request to match CMS-only code snippet here https://www.twilio.com/docs/admin/snippets/code_samples/codesample/edit/4530/. 

The problem with the CMS-only code snippet is that different spacing is showing up in the code snippet when used on the doc vs when it's viewed solitarily as a code snippet in the CMS.

https://twilio.slack.com/archives/C0M0WNMST/p1679338245304039