### PR TITLE
Go access token examples

### DIFF
--- a/rest/access-tokens/ip-messaging-example/ip-messaging-example.1.x.go
+++ b/rest/access-tokens/ip-messaging-example/ip-messaging-example.1.x.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go/client/jwt"
+)
+
+func main() {
+	// Get your Account SID from https://twilio.com/console
+	// To set up environment variables, see http://twil.io/secure
+	// Required for all types of tokens
+	var twilioAccountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var twilioApiKey string = os.Getenv("TWILIO_API_KEY")
+	var twilioApiSecret string = os.Getenv("TWILIO_API_SECRET")
+
+	params := jwt.AccessTokenParams{
+		AccountSid:    twilioAccountSid,
+		SigningKeySid: twilioApiKey,
+		Secret:        twilioApiSecret,
+		Identity:      "user@example.com",
+	}
+
+	jwtToken := jwt.CreateAccessToken(params)
+	chatGrant := &jwt.ChatGrant{
+		ServiceSid: "ISxxxxxxxxxxxx",
+	}
+
+	jwtToken.AddGrant(chatGrant)
+	token, err := jwtToken.ToJwt()
+
+	if err != nil {
+		error := fmt.Errorf("error: %q", err)
+		fmt.Println(error.Error())
+	}
+
+	fmt.Println(token)
+}

--- a/rest/access-tokens/sync-example/sync-example.1.x.go
+++ b/rest/access-tokens/sync-example/sync-example.1.x.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go/client/jwt"
+)
+
+func main() {
+	// Get your Account SID from https://twilio.com/console
+	// To set up environment variables, see http://twil.io/secure
+	// Required for all types of tokens
+	var twilioAccountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var twilioApiKey string = os.Getenv("TWILIO_API_KEY")
+	var twilioApiSecret string = os.Getenv("TWILIO_API_SECRET")
+	var twilioSyncService string = os.Getenv("TWILIO_SYNC_SERVICE_SID")
+
+	params := jwt.AccessTokenParams{
+		AccountSid:    twilioAccountSid,
+		SigningKeySid: twilioApiKey,
+		Secret:        twilioApiSecret,
+		Identity:      "user",
+	}
+
+	jwtToken := jwt.CreateAccessToken(params)
+	syncGrant := &jwt.SyncGrant{
+		ServiceSid: twilioSyncService,
+	}
+
+	jwtToken.AddGrant(syncGrant)
+	token, err := jwtToken.ToJwt()
+
+	if err != nil {
+		error := fmt.Errorf("error: %q", err)
+		fmt.Println(error.Error())
+	}
+
+	fmt.Println(token)
+}

--- a/rest/access-tokens/sync-example/sync-example.8.x.py
+++ b/rest/access-tokens/sync-example/sync-example.8.x.py
@@ -7,7 +7,7 @@ from twilio.jwt.access_token.grants import SyncGrant
 account_sid = os.environ['TWILIO_ACCOUNT_SID']
 api_key = os.environ['TWILIO_API_KEY']
 api_secret = os.environ['TWILIO_API_KEY_SECRET']
-twilio_sync_service = os.environ[process.env.['TWILIO_SYNC_SERVICE_SID']
+twilio_sync_service = os.environ['TWILIO_SYNC_SERVICE_SID']
 
 # required for Sync grant
 identity = 'user'

--- a/rest/access-tokens/video-example/video-example.1.x.go
+++ b/rest/access-tokens/video-example/video-example.1.x.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go/client/jwt"
+)
+
+func main() {
+	// Get your Account SID from https://twilio.com/console
+	// To set up environment variables, see http://twil.io/secure
+	// Required for all types of tokens
+	var twilioAccountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var twilioApiKey string = os.Getenv("TWILIO_API_KEY")
+	var twilioApiSecret string = os.Getenv("TWILIO_API_SECRET")
+
+	params := jwt.AccessTokenParams{
+		AccountSid:    twilioAccountSid,
+		SigningKeySid: twilioApiKey,
+		Secret:        twilioApiSecret,
+		Identity:      "user",
+	}
+
+	jwtToken := jwt.CreateAccessToken(params)
+	videoGrant := &jwt.VideoGrant{
+		Room: "cool room",
+	}
+
+	jwtToken.AddGrant(videoGrant)
+	token, err := jwtToken.ToJwt()
+
+	if err != nil {
+		error := fmt.Errorf("error: %q", err)
+		fmt.Println(error.Error())
+	}
+
+	fmt.Println(token)
+}

--- a/rest/access-tokens/voice-example/voice-example.1.x.go
+++ b/rest/access-tokens/voice-example/voice-example.1.x.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go/client/jwt"
+)
+
+func main() {
+	// Get your Account SID from https://twilio.com/console
+	// To set up environment variables, see http://twil.io/secure
+	// Required for all types of tokens
+	var twilioAccountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var twilioApiKey string = os.Getenv("TWILIO_API_KEY")
+	var twilioApiSecret string = os.Getenv("TWILIO_API_SECRET")
+
+	var outgoing_application_sid string = os.Getenv("APxxxxxxxxxxxxx")
+
+	params := jwt.AccessTokenParams{
+		AccountSid:    twilioAccountSid,
+		SigningKeySid: twilioApiKey,
+		Secret:        twilioApiSecret,
+		Identity:      "user",
+	}
+
+	jwtToken := jwt.CreateAccessToken(params)
+	voiceGrant := &jwt.VoiceGrant{
+		Outgoing: jwt.Outgoing{
+			ApplicationSid: outgoing_application_sid,
+		},
+		Incoming: jwt.Incoming{
+			Allow: true,
+		},
+	}
+
+	jwtToken.AddGrant(voiceGrant)
+	token, err := jwtToken.ToJwt()
+
+	if err != nil {
+		error := fmt.Errorf("error: %q", err)
+		fmt.Println(error.Error())
+	}
+
+	fmt.Println(token)
+}


### PR DESCRIPTION
Create examples for Voice/Video/Sync/IP-Messaging Access Tokens using the Go Helper Library.

Also fixes a snippet of NodeJS code within the Python Sync example.