### PR TITLE
Add missing parameter on rest.notification.list-get-example-4.meta.json

### DIFF
--- a/rest/notification/list-get-example-4/meta.json
+++ b/rest/notification/list-get-example-4/meta.json
@@ -1,3 +1,4 @@
 {
-  "title": "Filter Notifications by a Range"
+  "title": "Filter Notifications by a Range",
+  "type": "server"
 }


### PR DESCRIPTION
This missing parameter is making fail the option to update all scripts. 