### PR TITLE
Add examples for creating ChatGrants with push credentials.

### DIFF
--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.1.x.go
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.1.x.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go/client/jwt"
+)
+
+func main() {
+	// Get your Account SID from https://twilio.com/console
+	// To set up environment variables, see http://twil.io/secure
+	// Required for all types of tokens
+	var twilioAccountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var twilioApiKey string = os.Getenv("TWILIO_API_KEY")
+	var twilioApiSecret string = os.Getenv("TWILIO_API_SECRET")
+
+	params := jwt.AccessTokenParams{
+		AccountSid:    twilioAccountSid,
+		SigningKeySid: twilioApiKey,
+		Secret:        twilioApiSecret,
+		Identity:      "user@example.com",
+	}
+
+	jwtToken := jwt.CreateAccessToken(params)
+	chatGrant := &jwt.ChatGrant{
+		ServiceSid:        "ISxxxxxxxxxxxx",
+		PushCredentialSid: "CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+
+	jwtToken.AddGrant(chatGrant)
+	token, err := jwtToken.ToJwt()
+
+	if err != nil {
+		error := fmt.Errorf("error: %q", err)
+		fmt.Println(error.Error())
+	}
+
+	fmt.Println(token)
+}

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.4.x.js
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.4.x.js
@@ -1,0 +1,34 @@
+const AccessToken = require('twilio').jwt.AccessToken;
+const ChatGrant = AccessToken.ChatGrant;
+
+// Used when generating any kind of tokens
+// To set up environmental variables, see http://twil.io/secure
+const twilioAccountSid = process.env.TWILIO_ACCOUNT_SID;
+const twilioApiKey = process.env.TWILIO_API_KEY;
+const twilioApiSecret = process.env.TWILIO_API_SECRET;
+
+// Used specifically for creating Chat tokens
+const serviceSid = process.env.TWILIO_CHAT_SERVICE_SID;
+const pushCredentialSid = process.env.TWILIO_PUSH_CREDENTIAL_SID;
+const identity = 'user@example.com';
+
+// Create a "grant" which enables a client to use Chat as a given user,
+// on a given device
+const chatGrant = new ChatGrant({
+  serviceSid: serviceSid,
+  push_credential_sid: pushCredentialSid
+});
+
+// Create an access token which we will sign and return to the client,
+// containing the grant we just created
+const token = new AccessToken(
+  twilioAccountSid,
+  twilioApiKey,
+  twilioApiSecret,
+  {identity: identity}
+);
+
+token.addGrant(chatGrant);
+
+// Serialize the token to a JWT string
+console.log(token.toJwt());

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.6.x.cs
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.6.x.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Twilio.Jwt.AccessToken;
+
+class Example
+{
+    static void Main(string[] args)
+    {
+        // These values are necessary for any access token
+        // To set up environmental variables, see http://twil.io/secure
+        const string twilioAccountSid = Environment.GetEnvironmentVariable("TWILIO_ACCOUNT_SID");
+        const string twilioApiKey = Environment.GetEnvironmentVariable("TWILIO_API_KEY");
+        const string twilioApiSecret = Environment.GetEnvironmentVariable("TWILIO_API_SECRET");
+
+        // These are specific to Chat
+        const string serviceSid = Environment.GetEnvironmentVariable("TWILIO_SERVICE_SID");
+        const string pushCredentialSid = Environment.GetEnvironmentVariable("TWILIO_PUSH_CREDENTIAL_SID");
+        const string identity = "user@example.com";
+
+        // Create an Chat grant for this token
+
+        var grant = new ChatGrant
+        {
+          ServiceSid = serviceSid,
+          PushCredentialSid = pushCredentialSid
+        };
+
+        var grants = new HashSet<IGrant>
+        {
+            { grant }
+        };
+
+        // Create an Access Token generator
+        var token = new Token(
+            twilioAccountSid,
+            twilioApiKey,
+            twilioApiSecret,
+            identity,
+            grants: grants);
+
+        Console.WriteLine(token.ToJwt());
+    }
+}

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.6.x.rb
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.6.x.rb
@@ -1,0 +1,29 @@
+require 'twilio-ruby'
+
+# Required for any Twilio Access Token
+# To set up environmental variables, see http://twil.io/secure
+account_sid = ENV['TWILIO_ACCOUNT_SID']
+api_key = ENV['TWILIO_API_KEY']
+api_secret = ENV['TWILIO_API_KEY_SECRET']
+
+# Required for Chat
+service_sid = 'ISxxxxxxxxxxxx'
+push_credential_sid = 'CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+identity = 'user@example.com'
+
+# Create Chat grant for our token
+grant = Twilio::JWT::AccessToken::ChatGrant.new
+grant.service_sid = service_sid
+grant.push_credential_sid = push_credential_sid
+
+# Create an Access Token
+token = Twilio::JWT::AccessToken.new(
+  account_sid,
+  api_key,
+  api_secret,
+  [grant],
+  identity: identity
+)
+
+# Generate the token
+puts token.to_jwt

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.7.x.php
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.7.x.php
@@ -1,0 +1,37 @@
+<?php
+// Get the PHP helper library from https://twilio.com/docs/libraries/php
+require_once '/path/to/vendor/autoload.php'; // Loads the library
+use Twilio\Jwt\AccessToken;
+use Twilio\Jwt\Grants\ChatGrant;
+
+// Required for all Twilio access tokens
+// To set up environmental variables, see http://twil.io/secure
+$twilioAccountSid = getenv('TWILIO_ACCOUNT_SID');
+$twilioApiKey = getenv('TWILIO_API_KEY');
+$twilioApiSecret = getenv('TWILIO_API_KEY_SECRET');
+
+// Required for Chat grant
+$serviceSid = 'ISxxxxxxxxxxxx';
+$pushCredentialSid = 'CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+// choose a random username for the connecting user
+$identity = "john_doe";
+
+// Create access token, which we will serialize and send to the client
+$token = new AccessToken(
+    $twilioAccountSid,
+    $twilioApiKey,
+    $twilioApiSecret,
+    3600,
+    $identity
+);
+
+// Create Chat grant
+$chatGrant = new ChatGrant();
+$chatGrant->setServiceSid($serviceSid);
+$chatGrant->setPushCredentialSid($pushCredentialSid);
+
+// Add grant to token
+$token->addGrant($chatGrant);
+
+// render token to string
+echo $token->toJWT();

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.8.x.py
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.8.x.py
@@ -1,0 +1,24 @@
+import os
+from twilio.jwt.access_token import AccessToken
+from twilio.jwt.access_token.grants import ChatGrant
+
+# required for all twilio access tokens
+# To set up environmental variables, see http://twil.io/secure
+account_sid = os.environ['TWILIO_ACCOUNT_SID']
+api_key = os.environ['TWILIO_API_KEY']
+api_secret = os.environ['TWILIO_API_KEY_SECRET']
+
+# required for Chat grants
+service_sid = 'ISxxxxxxxxxxxx'
+push_credential_sid = 'CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+identity = 'user@example.com'
+
+# Create access token with credentials
+token = AccessToken(account_sid, api_key, api_secret, identity=identity)
+
+# Create an Chat grant and add to token
+chat_grant = ChatGrant(service_sid=service_sid, push_credential_sid=push_credential_sid)
+token.add_grant(chat_grant)
+
+# Return token info as JSON
+print(token.to_jwt())

--- a/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.9.x.java
+++ b/rest/access-tokens/ip-messaging-example-push-credential/ip-messaging-example.9.x.java
@@ -1,0 +1,26 @@
+import com.twilio.jwt.accesstoken.AccessToken;
+import com.twilio.jwt.accesstoken.ChatGrant;
+
+public class Example {
+  public static void main(String[] args) {
+    // Get your Account SID from https://twilio.com/console
+    // To set up environment variables, see http://twil.io/secure
+    // Required for all types of tokens
+    String twilioAccountSid = System.getenv("TWILIO_ACCOUNT_SID");
+    String twilioApiKey = System.getenv("TWILIO_API_KEY");
+    String twilioApiSecret = System.getenv("TWILIO_API_SECRET");
+
+    String serviceSid = System.getenv("TWILIO_SERVICE_SID");
+    String pushCredentialSid = System.getenv("TWILIO_PUSH_CREDENTIAL_SID");
+    String identity = "user@example.com";
+
+    ChatGrant grant = new ChatGrant();
+    grant.setServiceSid(serviceSid);
+    grant.setPushCredentialSid(pushCredentialSid);
+
+    AccessToken token = new AccessToken.Builder(twilioAccountSid, twilioApiKey, twilioApiSecret)
+        .identity(identity).grant(grant).build();
+
+    System.out.println(token.toJwt());
+  }
+}

--- a/rest/access-tokens/ip-messaging-example-push-credential/meta.json
+++ b/rest/access-tokens/ip-messaging-example-push-credential/meta.json
@@ -1,0 +1,4 @@
+{
+  "type": "server",
+  "title": "Creating an Access Token (Chat) with Push Credentials"
+}


### PR DESCRIPTION
These code samples are copied directly from [this example set](https://github.com/TwilioDevEd/api-snippets/tree/master/rest/access-tokens/ip-messaging-example) and I added the pushCredentialSid to each ChatGrant.

I've tested these to make sure they run.