### PR TITLE
Move code snippets from docs to GitHub

### DIFF
--- a/voice/specify-edge/meta.json
+++ b/voice/specify-edge/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Specify a Twilio Region and Edge when making a call",
+  "type": "server"
+}

--- a/voice/specify-edge/specify-edge.1.x.go
+++ b/voice/specify-edge/specify-edge.1.x.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/twilio/twilio-go"
+	twilioApi "github.com/twilio/twilio-go/rest/api/v2010"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+
+	var accountSid string = os.Getenv("TWILIO_ACCOUNT_SID")
+	var apiKeySid string = os.Getenv("TWILIO_API_KEY")
+	var apiKeySecret string = os.Getenv("TWILIO_API_SECRET")
+
+	var to_number = os.Getenv("TO_NUMBER")
+	var from_number = os.Getenv("FROM_NUMBER")
+
+	client := twilio.NewRestClientWithParams(twilio.ClientParams{
+		Username:   apiKeySid,
+		Password:   apiKeySecret,
+		AccountSid: accountSid,
+	})
+
+	client.SetRegion("ie1")
+	client.SetEdge("dublin")
+
+	params := &twilioApi.CreateCallParams{}
+	params.SetTo(to_number)
+	params.SetFrom(from_number)
+
+	say := &twiml.VoiceSay{
+		Message: "Ahoy from Ireland",
+	}
+
+	twimlResult, twimlErr := twiml.Voice([]twiml.Element{say})
+	if twimlErr != nil {
+		fmt.Println(twimlErr)
+	} else {
+		params.SetTwiml(twimlResult)
+	}
+
+	callResp, callErr := client.Api.CreateCall(params)
+	if callErr != nil {
+		fmt.Println(callErr.Error())
+	} else {
+		fmt.Println("Call Sid: ", *callResp.Sid)
+	}
+}

--- a/voice/specify-edge/specify-edge.4.x.js
+++ b/voice/specify-edge/specify-edge.4.x.js
@@ -1,0 +1,21 @@
+const accountSid = process.env.ACCOUNT_SID;
+const apiKeySid = process.env.API_KEY_SID;
+const apiKeySecret = process.env.API_KEY_SECRET;
+
+const toNumber = process.env.TO_NUMBER;
+const fromNumber = process.env.FROM_NUMBER;
+
+const client = require('twilio')(
+    apiKeySid,
+    apiKeySecret, {
+        accountSid: accountSid,
+        edge: 'dublin',
+        region: 'ie1'
+    });
+
+client.calls
+    .create({
+        twiml: '<Response><Say>Ahoy from Ireland</Say></Response>',
+        to: toNumber,
+        from: fromNumber
+    });

--- a/voice/specify-edge/specify-edge.6.x.cs
+++ b/voice/specify-edge/specify-edge.6.x.cs
@@ -1,0 +1,31 @@
+using Twilio;
+using Twilio.Rest.Api.V2010.Account;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string accountSid = Environment.GetEnvironmentVariable("ACCOUNT_SID");
+        string apiKeySid = Environment.GetEnvironmentVariable("API_KEY_SID");
+        string apiKeySecret = Environment.GetEnvironmentVariable("API_KEY_SECRET");
+
+        string toNumber = Environment.GetEnvironmentVariable("TO_NUMBER");
+        string fromNumber = Environment.GetEnvironmentVariable("FROM_NUMBER");
+
+        TwilioClient.Init(
+            apiKeySid,
+            apiKeySecret,
+            accountSid=accountSid,
+        );
+
+        TwilioClient.SetRegion("ie1");
+        TwilioClient.SetEdge("dublin");
+
+
+        var call = CallResource.Create(
+            twiml: new Twilio.Types.Twiml("<Response><Say>Ahoy from Ireland</Say></Response>"),
+            to: new Twilio.Types.PhoneNumber(toNumber),
+            from: new Twilio.Types.PhoneNumber(fromNumber)
+        );
+    }
+}

--- a/voice/specify-edge/specify-edge.6.x.rb
+++ b/voice/specify-edge/specify-edge.6.x.rb
@@ -1,0 +1,23 @@
+require "twilio-ruby"
+
+account_sid = ENV["ACCOUNT_SID"]
+api_key_sid = ENV["API_KEY_SID"]
+api_key_secret = ENV["API_KEY_SECRET"]
+
+to_number = ENV["TO_NUMBER"]
+from_number = ENV["FROM_NUMBER"]
+
+@client = Twilio::REST::Client.new(
+    api_key_sid,
+    api_key_secret,
+    account_sid
+)
+
+@client.edge = "dublin"
+@client.region = "ie1"
+
+call = @client.calls.create(
+    twiml: '<Response><Say>Ahoy from Ireland</Say></Response>',
+    to: to_number,
+    from: from_number
+)

--- a/voice/specify-edge/specify-edge.7.x.php
+++ b/voice/specify-edge/specify-edge.7.x.php
@@ -1,0 +1,30 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+$account_sid = getenv("ACCOUNT_SID");
+$api_key_sid = getenv("API_KEY_SID");
+$api_key_secret = getenv("API_KEY_SECRET");
+
+$to_number = getenv("TO_NUMBER");
+$from_number = getenv("FROM_NUMBER");
+
+$twilio = new Client(
+    $api_key_sid,
+    $api_key_secret,
+    $account_sid,
+    "ie1");
+
+$twilio -> setEdge("dublin");
+
+$call = $twilio->calls
+               ->create($to_number,
+                        $from_number,
+                        [
+                            "twiml" => "<Response><Say>Ahoy from Ireland</Say></Response>"
+                        ]
+               );

--- a/voice/specify-edge/specify-edge.8.x.py
+++ b/voice/specify-edge/specify-edge.8.x.py
@@ -1,0 +1,24 @@
+import os
+from twilio.rest import Client
+
+
+account_sid = os.environ['ACCOUNT_SID']
+api_key_sid = os.environ['API_KEY_SID']
+api_key_secret = os.environ['API_KEY_SECRET']
+
+to_number = os.environ['TO_NUMBER']
+from_number = os.environ['FROM_NUMBER']
+
+client = Client(
+    account_sid=account_sid,
+    username=api_key_sid,
+    password=api_key_secret,
+    edge='dublin',
+    region='ie1'
+)
+
+call = client.calls.create(
+    twiml='<Response><Say>Ahoy from Ireland</Say></Response>',
+    to=to_number,
+    from_=from_number
+)

--- a/voice/specify-edge/specify-edge.9.x.java
+++ b/voice/specify-edge/specify-edge.9.x.java
@@ -1,0 +1,26 @@
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Call;
+import com.twilio.type.PhoneNumber;
+import com.twilio.type.Twiml;
+
+public class Example {
+
+    public static final String ACCOUNT_SID = System.getenv("ACCOUNT_SID");
+    public static final String API_KEY_SID = System.getenv("API_KEY_SID");
+    public static final String API_KEY_SECRET = System.getenv("API_KEY_SECRET");
+
+    public static final String TO_NUMBER = System.getenv("TO_NUMBER");
+    public static final String FROM_NUMBER = System.getenv("FROM_NUMBER");
+
+    public static void main(String[] args) {
+        Twilio.init(API_KEY_SID, API_KEY_SECRET, ACCOUNT_SID);
+        Twilio.setEdge("dublin");
+        Twilio.setRegion("ie1");
+        
+        Call call = Call.creator(
+                new com.twilio.type.PhoneNumber(TO_NUMBER),
+                new com.twilio.type.PhoneNumber(FROM_NUMBER),
+                new com.twilio.type.Twiml("<Response><Say>Ahoy from Ireland</Say></Response>"))
+            .create();
+    }
+}


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/DEVED-8517

Takes the code samples from this page https://www.twilio.com/docs/global-infrastructure/create-an-outbound-call-via-rest-api-in-a-non-us-twilio-region and puts them into this repo.

The Tabbed Content component in Wagtail only supports up to 6 code samples, so I can't add another one for Go in the existing doc as it is.

I tested the new Go code sample, and the others are taken directly from the docs.