### PR TITLE
Create example for responding to incoming message with empty TwiML.

### DIFF
--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.1.x.go
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.1.x.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.POST("/sms", func(context *gin.Context) {
+		twimlResult, err := twiml.Messages()
+		if err != nil {
+			context.String(http.StatusInternalServerError, err.Error())
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
+	})
+
+	router.Run(":3000")
+}

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.4.x.js
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.4.x.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const { MessagingResponse } = require('twilio').twiml;
+
+const app = express();
+
+app.post('/sms', (req, res) => {
+  const twiml = new MessagingResponse();
+
+  res.type('text/xml').send(twiml.toString());
+});
+
+app.listen(3000, () => {
+  console.log('Express server listening on port 3000');
+});

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.6.x.cs
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.6.x.cs
@@ -1,0 +1,20 @@
+// In Package Manager, run:
+// Install-Package Twilio.AspNet.Mvc -DependencyVersion HighestMinor
+
+using System.Web.Mvc;
+using Twilio.AspNet.Mvc;
+using Twilio.TwiML;
+
+namespace YourNewWebProject.Controllers
+{
+    public class SmsController : TwilioController
+    {
+        [HttpPost]
+        public TwiMLResult Index()
+        {
+            var messagingResponse = new MessagingResponse();
+
+            return TwiML(messagingResponse);
+        }
+    }
+}

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.6.x.rb
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.6.x.rb
@@ -1,0 +1,11 @@
+require 'twilio-ruby'
+require 'sinatra'
+
+# Respond to incoming calls with a simple text message
+post '/sms' do
+  twiml = Twilio::TwiML::MessagingResponse.new
+
+  content_type 'text/xml'
+
+  twiml.to_s
+end

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.7.x.php
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.7.x.php
@@ -1,0 +1,8 @@
+<?php
+// Get the PHP helper library from https://twilio.com/docs/libraries/php
+
+require_once 'vendor/autoload.php'; // Loads the library
+use Twilio\TwiML\MessagingResponse;
+
+$response = new MessagingResponse();
+print $response;

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.8.x.py
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.8.x.py
@@ -1,0 +1,15 @@
+from flask import Flask, request, redirect
+from twilio.twiml.messaging_response import MessagingResponse
+
+app = Flask(__name__)
+
+@app.route("/sms", methods=['GET', 'POST'])
+def sms_reply():
+    """Receive incoming messages without sending a message response."""
+    # Start our TwiML response
+    resp = MessagingResponse()
+
+    return str(resp)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.9.x.java
+++ b/rest/messages/generate-twiml-empty-response/generate-twiml-empty-response.9.x.java
@@ -1,0 +1,17 @@
+import com.twilio.twiml.MessagingResponse;
+import com.twilio.twiml.messaging.Body;
+import com.twilio.twiml.messaging.Message;
+
+import static spark.Spark.*;
+
+public class SmsApp {
+    public static void main(String[] args) {
+        get("/", (req, res) -> "Hello Web");
+
+        post("/sms", (req, res) -> {
+            res.type("application/xml");
+            MessagingResponse twiml = new MessagingResponse.Builder().build();
+            return twiml.toXml();
+        });
+    }
+}

--- a/rest/messages/generate-twiml-empty-response/meta.json
+++ b/rest/messages/generate-twiml-empty-response/meta.json
@@ -1,0 +1,5 @@
+{
+  "testable": "false",
+  "type": "server",
+  "title": "Receive an incoming message without sending a response",
+}


### PR DESCRIPTION
[DEVED-5017](https://issues.corp.twilio.com/browse/DEVED-5017)
Show how to respond to an incoming message request with nothing (by not sending a message back and just receiving the message).
I copied these from the existing [generate-twiml-sms](https://github.com/TwilioDevEd/api-snippets/tree/master/rest/messages/generate-twiml-sms) examples and altered them to send a blank TwiML response.