### PR TITLE
[Fix] Remove backticks for general usage pages serialisation

### DIFF
--- a/guides/request-validation-php-lumen/example-1/meta.json
+++ b/guides/request-validation-php-lumen/example-1/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Create Lumen middleware to handle and validate requests",
-  "description": "Use Twilio SDK `RequestValidator` to validate webhook requests.",
+  "description": "Use Twilio SDK RequestValidator to validate webhook requests.",
   "type": "server"
 }

--- a/guides/request-validation-php-lumen/example-3/meta.json
+++ b/guides/request-validation-php-lumen/example-3/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Disable Twilio request validation when testing",
-  "description": "Use `APP_ENV` environment variable to disable request validation.",
+  "description": "Use APP_ENV environment variable to disable request validation.",
   "type": "server"
 }


### PR DESCRIPTION
This characters in the tittle or description are making fail the serialisation of some pages. 