### PR TITLE
Add content templates location samples

### DIFF
--- a/messaging/content-templates/create-location-template/create-location-template.curl
+++ b/messaging/content-templates/create-location-template/create-location-template.curl
@@ -1,0 +1,17 @@
+curl -X POST 'https://content.twilio.com/v1/Content' \
+-H 'Content-Type: application/json' \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN \
+-d '{
+    "friendly_name": "Owl Air location template",
+    "language": "en",
+    "types": {
+        "twilio/text": {
+            "body": "Owl Air: Time to board, SFO is located at San Francisco International Airport, P.O. Box 8097, San Francisco, CA 94128 "
+        },
+        "twilio/location": {
+            "latitude": 37.62159755922449,
+            "longitude": -122.37888566473057,
+            "label": "Time to Board @ SFO"
+        }
+    }
+}'

--- a/messaging/content-templates/create-location-template/meta.json
+++ b/messaging/content-templates/create-location-template/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Content Templates API - Create a Location Template",
+  "highlight": "{}",
+  "title_override": "Create Location Template",
+  "description_override": ""
+}

--- a/messaging/content-templates/create-location-template/output/create-location-template.json
+++ b/messaging/content-templates/create-location-template/output/create-location-template.json
@@ -1,0 +1,24 @@
+{
+  "language": "en",
+  "date_updated": "2022-08-29T15:23:12Z",
+  "variables": null,
+  "friendly_name": "Owl Air location template",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "date_created": "2022-08-29T15:23:12Z",
+  "types": {
+    "twilio/text": {
+      "body": "Owl Air: Time to board, SFO is located at San Francisco International Airport, P.O. Box 8097, San Francisco, CA 94128 "
+    },
+    "twilio/location": {
+      "latitude": 37.62159755922449,
+      "longitude": -122.37888566473057,
+      "label": "Time to Board @ SFO"
+    }
+  },
+  "links": {
+    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests",
+    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp"
+  }
+}

--- a/messaging/content-templates/create-location-template/output/create-location-template.json
+++ b/messaging/content-templates/create-location-template/output/create-location-template.json
@@ -1,24 +1,24 @@
 {
-  "language": "en",
-  "date_updated": "2022-08-29T15:23:12Z",
-  "variables": null,
-  "friendly_name": "Owl Air location template",
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "date_created": "2022-08-29T15:23:12Z",
+  "date_updated": "2022-08-29T15:23:12Z",
+  "friendly_name": "Owl Air location template",
+  "language": "en",
+  "links": {
+    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp",
+    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests"
+  },
+  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "types": {
+    "twilio/location": {
+      "label": "Time to Board @ SFO",
+      "latitude": 37.62159755922449,
+      "longitude": -122.37888566473057
+    },
     "twilio/text": {
       "body": "Owl Air: Time to board, SFO is located at San Francisco International Airport, P.O. Box 8097, San Francisco, CA 94128 "
-    },
-    "twilio/location": {
-      "latitude": 37.62159755922449,
-      "longitude": -122.37888566473057,
-      "label": "Time to Board @ SFO"
     }
   },
-  "links": {
-    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests",
-    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp"
-  }
+  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "variables": {}
 }


### PR DESCRIPTION
[DEVED-10492](https://twilio-productivity.atlassian.net/browse/DEVED-10492)

This adds a sample from the [docs repo](https://github.com/twilio-internal/docs/tree/4a43d9ca98823e77d1c5942480c686ad1c247e8c/docs/content). 

I may have changed friendly name values, updated for style guide, and I updated the naming of the files to match the requirements of this repo. 

To review: 
- Make sure that the three/four files match logically. The request params match the output params, etc. 
Thanks!