### PR TITLE
Add list picker content templates sample

### DIFF
--- a/messaging/content-templates/create-list-picker-template/create-list-picker-template.curl
+++ b/messaging/content-templates/create-list-picker-template/create-list-picker-template.curl
@@ -1,0 +1,36 @@
+curl -X POST 'https://content.twilio.com/v1/Content' \
+-H 'Content-Type: application/json' \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN \
+-d '{
+    "friendly_name": "Owl Air list picker template",
+    "language": "en",
+    "variables": {
+        "1": "end_date"
+    },
+    "types": {
+        "twilio/list-picker": {
+            "body": "Owl Air Flash Sale! Hurry! Sale ends on {{1}}!",
+            "button": "Select a destination",
+            "items": [
+                {
+                    "item": "SFO to NYC for $299",
+                    "description": "Owl Air Flight 1337 to LGA",
+                    "id": "SFO1337"
+                },
+                {
+                    "item": "OAK to Denver for $149",
+                    "description": "Owl Air Flight 5280 to DEN",
+                    "id": "OAK5280"
+                },
+                {
+                    "item": "LAX to Chicago for $199",
+                    "description": "Owl Air Flight 96 to ORD",
+                    "id": "LAX96"
+                }
+            ]
+        },
+       "twilio/text": {
+            "body": "We have flights to the following destinations: (1) New York City, (2) Denver, (3) Chicago. Hurry! Sale ends on {{1}}!"
+        }
+    }
+}'    

--- a/messaging/content-templates/create-list-picker-template/meta.json
+++ b/messaging/content-templates/create-list-picker-template/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Content Templates API  - Create a List Picker Template",
+  "highlight": "{}",
+  "title_override": "Create List Picker Template",
+  "description_override": ""
+}

--- a/messaging/content-templates/create-list-picker-template/output/create-list-picker-template.json
+++ b/messaging/content-templates/create-list-picker-template/output/create-list-picker-template.json
@@ -1,42 +1,42 @@
 {
-  "language": "en",
-  "date_updated": "2022-08-29T15:46:11Z",
-  "variables": {
-    "1": "end_date"
-  },
-  "friendly_name": "Owl Air list picker template",
   "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "date_created": "2022-08-29T15:46:11Z",
+  "date_updated": "2022-08-29T15:46:11Z",
+  "friendly_name": "Owl Air list picker template",
+  "language": "en",
+  "links": {
+    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp",
+    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests"
+  },
+  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "types": {
     "twilio/list-picker": {
       "body": "Owl Air Flash Sale! Hurry! Sale ends on {{1}}!",
+      "button": "Select a destination",
       "items": [
         {
-          "item": "SFO to NYC for $299",
+          "description": "Owl Air Flight 1337 to LGA",
           "id": "SFO1337",
-          "description": "Owl Air Flight 1337 to LGA"
+          "item": "SFO to NYC for $299"
         },
         {
-          "item": "OAK to Denver for $149",
+          "description": "Owl Air Flight 5280 to DEN",
           "id": "OAK5280",
-          "description": "Owl Air Flight 5280 to DEN"
+          "item": "OAK to Denver for $149"
         },
         {
-          "item": "LAX to Chicago for $199",
+          "description": "Owl Air Flight 96 to ORD",
           "id": "LAX96",
-          "description": "Owl Air Flight 96 to ORD"
+          "item": "LAX to Chicago for $199"
         }
-      ],
-      "button": "Select a destination"
+      ]
     },
     "twilio/text": {
       "body": "We have flights to the following destinations: (1) SFO, (2) OAK, (3) LAX. Hurry! Sale ends on {{1}}!"
     }
   },
-  "links": {
-    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests",
-    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp"
+  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "variables": {
+    "1": "end_date"
   }
 }

--- a/messaging/content-templates/create-list-picker-template/output/create-list-picker-template.json
+++ b/messaging/content-templates/create-list-picker-template/output/create-list-picker-template.json
@@ -1,0 +1,42 @@
+{
+  "language": "en",
+  "date_updated": "2022-08-29T15:46:11Z",
+  "variables": {
+    "1": "end_date"
+  },
+  "friendly_name": "Owl Air list picker template",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "url": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "sid": "HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "date_created": "2022-08-29T15:46:11Z",
+  "types": {
+    "twilio/list-picker": {
+      "body": "Owl Air Flash Sale! Hurry! Sale ends on {{1}}!",
+      "items": [
+        {
+          "item": "SFO to NYC for $299",
+          "id": "SFO1337",
+          "description": "Owl Air Flight 1337 to LGA"
+        },
+        {
+          "item": "OAK to Denver for $149",
+          "id": "OAK5280",
+          "description": "Owl Air Flight 5280 to DEN"
+        },
+        {
+          "item": "LAX to Chicago for $199",
+          "id": "LAX96",
+          "description": "Owl Air Flight 96 to ORD"
+        }
+      ],
+      "button": "Select a destination"
+    },
+    "twilio/text": {
+      "body": "We have flights to the following destinations: (1) SFO, (2) OAK, (3) LAX. Hurry! Sale ends on {{1}}!"
+    }
+  },
+  "links": {
+    "approval_fetch": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests",
+    "approval_create": "https://content.twilio.com/v1/Content/HXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/ApprovalRequests/whatsapp"
+  }
+}


### PR DESCRIPTION
[DEVED-10492](https://twilio-productivity.atlassian.net/browse/DEVED-10492)

This adds a sample from the [docs repo](https://github.com/twilio-internal/docs/tree/4a43d9ca98823e77d1c5942480c686ad1c247e8c/docs/content). 

I may have changed friendly name values, updated for style guide, and I updated the naming of the files to match the requirements of this repo. 

To review: 
- Make sure that the three/four files match logically. The request params match the output params, etc. 
Thanks!